### PR TITLE
Convert dynamics to bullets, add metadata & sort, revive comparisons page

### DIFF
--- a/COMPARISONS.md
+++ b/COMPARISONS.md
@@ -1,141 +1,90 @@
 # Comparisons
 
-> **Note**: The comparison data below was last comprehensively updated in 2016. While the structural information is still useful, specific feature details may be outdated. Contributions to update these tables are very welcome — please see [CONTRIBUTING.md](CONTRIBUTING.md).
+A companion to the main [Awesome Robotics Libraries](README.md) list, providing side-by-side comparisons of physics engines and dynamics libraries commonly used in robotics.
 
-#### Table of Contents
-* [Multibody Dynamics Libraries](#multibody-dynamics-libraries)
-* [Simulators](#simulators)
+## Contents
 
-## [Multibody Dynamics Libraries](#awesome-robotics-libraries)
+* [Physics Engine Feature Matrix](#physics-engine-feature-matrix)
+* [Robotics Dynamics Libraries](#robotics-dynamics-libraries)
+* [Decision Guide](#decision-guide)
+* [Benchmark Resources](#benchmark-resources)
 
-Comparisons inspired by [Wikipedia's Robotics simulator](https://en.wikipedia.org/wiki/Robotics_simulator#Simulators) page. 
-> :warning: **Warning**: Most fields are missing. Any help would be appreciated.
+## Physics Engine Feature Matrix
 
-### [Selected Libraries to Compare](#Comparisons)
+| Name | Rigid | Soft | Fluids | Contact | Differentiable | GPU | Language | License |
+|------|:-----:|:----:|:------:|:-------:|:--------------:|:---:|----------|---------|
+| [Bullet](https://pybullet.org/) | ✅ | ✅ | ❌ | Impulse, PGS | ❌ | ❌ | C++ | Zlib |
+| [CHRONO](https://projectchrono.org/) | ✅ | ✅ | ✅ | DVI, SMC | ❌ | ✅ | C++ | BSD-3 |
+| [DART](http://dartsim.github.io/) | ✅ | ✅ | ❌ | LCP, PGS | ❌ | ❌ | C++ | BSD-2 |
+| [Drake](https://drake.mit.edu/) | ✅ | ⚠️ | ⚠️ | SAP, TAMSI | ✅ | ❌ | C++ | BSD-3 |
+| [Flex](https://developer.nvidia.com/flex) | ✅ | ✅ | ✅ | Particle-based | ❌ | ✅ | C++ | — |
+| [MuJoCo](https://mujoco.org/) | ✅ | ✅ | ❌ | Complementarity | ✅ (MJX) | ✅ (MJX) | C++ | Apache-2.0 |
+| [Newton Dynamics](https://newtondynamics.com/) | ✅ | ❌ | ❌ | Impulse | ❌ | ❌ | C++ | Zlib |
+| [nphysics](https://nphysics.org/) | ✅ | ❌ | ❌ | Impulse | ❌ | ❌ | Rust | BSD-3 |
+| [ODE](https://ode.org/) | ✅ | ❌ | ❌ | LCP | ❌ | ❌ | C++ | LGPL/BSD |
+| [PhysX](https://nvidia-omniverse.github.io/PhysX/) | ✅ | ✅ | ✅ | TGS, PGS | ❌ | ✅ | C++ | BSD-3 |
+| [pinocchio](https://stack-of-tasks.github.io/pinocchio/) | ✅ | ❌ | ❌ | — | ✅ | ❌ | C++ | BSD-2 |
+| [ReactPhysics3d](https://www.reactphysics3d.com/) | ✅ | ❌ | ❌ | Impulse | ❌ | ❌ | C++ | Zlib |
+| [Simbody](https://simtk.org/home/simbody/) | ✅ | ❌ | ❌ | Complementarity | ❌ | ❌ | C++ | Apache-2.0 |
+| [SOFA](https://www.sofa-framework.org/) | ✅ | ✅ | ❌ | Penalty, LM | ❌ | ✅ | C++ | LGPL-2.1 |
+| [Tiny Diff. Sim.](https://github.com/erwincoumans/tiny-differentiable-simulator) | ✅ | ❌ | ❌ | Impulse | ✅ | ❌ | C++ | Apache-2.0 |
 
-* [Bullet](https://pybullet.org/wordpress/) ([github](https://github.com/bulletphysics/bullet3)) - Real-Time Physics Simulation
-* [CHRONO::ENGINE](https://projectchrono.org/) ([github](https://github.com/projectchrono/chrono)) - C++ library for multibody dynamics simulations.
-* [DART](http://dartsim.github.io/) ([github](https://github.com/dartsim/dart)) - Dynamic Animation and Robotics Toolkit.
-* [Drake](https://drake.mit.edu/) ([github](https://github.com/RobotLocomotion/drake)) - A planning, control, and analysis toolbox for nonlinear dynamical systems.
-* [ODE](https://ode.org/) ([bitbucket](https://bitbucket.org/odedevs/ode)) - An open source, high performance library for simulating rigid body dynamics.
-* [Simbody](https://simtk.org/home/simbody/) ([github](https://github.com/simbody/simbody)) - A multibody dynamics/physics library for simulating articulated biomechanical/mechanical systems.
+**Legend**: ✅ Supported · ❌ Not supported · ⚠️ Partial/limited support
 
-### General Information
+## Robotics Dynamics Libraries
 
-| Library  | Developer(s) | Latest Release | Platform Supported | License |
-|:--------:| ------------ | -------------- | ------------------ | ------- |
-| chrono   | [University of Wisconsin-Madison](http://www.projectchrono.org/about/) | IntPoint1.2 (2016-02-27) | Linux, Windows | BSD 3-Clause |
-| Bullet   | Erwin Coumans | 2.83 (2016-01-08) | Linux, MacOS, Windows | Zlib |
-| DART     | Georgia Tech and CMU | [6.0.0 (2016-05-10)](https://github.com/dartsim/dart/releases/tag/v6.0.0) | Linux, MacOS, Windows | BSD 2-Clause |
-| Drake    | MIT and TRI | 0.9.11 (2015-10-08) | Linux, MacOS, Windows | BSD 3-Clause |
-| ODE      | [Russell Smith](http://www.q12.org/) | [0.14 (2015-12-18)](https://bitbucket.org/odedevs/ode/commits/tag/0.14) | Linux, MacOS, Windows | LGPL 2.1 or BSD 3-Clause |
-| Simbody  | [Simtk.org](https://simtk.org/xml/index.xml) | 3.5.3 (2015-06-15) | Linux, MacOS, Windows | Apache 2.0 |
-:star: updated Apr 19, 2016
+Libraries commonly used for robot dynamics computation in research and applications.
 
-### Technical Information
+| Name | Forward Dyn. | Inverse Dyn. | IK | URDF | Python API | Analytical Derivatives | Active (2025+) |
+|------|:------------:|:------------:|:--:|:----:|:----------:|:---------------------:|:--------------:|
+| [pinocchio](https://github.com/stack-of-tasks/pinocchio) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| [DART](https://github.com/dartsim/dart) | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ |
+| [Drake](https://github.com/RobotLocomotion/drake) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| [MuJoCo](https://github.com/google-deepmind/mujoco) | ✅ | ✅ | ❌ | ❌ | ✅ | ✅ | ✅ |
+| [RBDL](https://github.com/rbdl/rbdl) | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ |
+| [Simbody](https://github.com/simbody/simbody) | ✅ | ✅ | ❌ | ✅ | ❌ | ❌ | ✅ |
+| [idyntree](https://github.com/gbionics/idyntree) | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ | ✅ |
+| [KDL](https://github.com/orocos/orocos_kinematics_dynamics) | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ |
+| [RBDyn](https://github.com/jrl-umi3218/RBDyn) | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ✅ |
 
-| Library  | Main Programming Language | External APIs | File Formats Support |
-|:--------:|:-------------------------:|:-------------:|:--------------------:|
-| chrono   | C++ | C++, Python | unknown |
-| Bullet   | C++ | C++ | URDF |
-| DART     | C++ | C++, Python | URDF, SDF, VSK, SKEL |
-| Drake    | C++ and MATLAB | C++, Python | own json format |
-| ODE      | C++ | C++ | unknown |
-| Simbody  | C++ | C++ | URDF |
+## Decision Guide
 
-### Support
+**Which library should I use?**
 
-| Library  | Mailing List | API Documentation | Public Forum/Help System | User Manual | Tutorial | Issue Tracker | Wiki |
-|:--------:|:------------:|:-----------------:|:------------------------:|:-----------:|:--------:|:-------------:|:----:|
-| DART    | No | [Yes](https://dartsim.github.io/) | No | No | [Yes](https://dart.readthedocs.io/) | [Yes](https://github.com/dartsim/dart/issues) | [Yes](https://github.com/dartsim/dart/wiki) |
+* **Robotics research (manipulation, locomotion):** [pinocchio](https://github.com/stack-of-tasks/pinocchio), [Drake](https://github.com/RobotLocomotion/drake), or [MuJoCo](https://github.com/google-deepmind/mujoco) — all actively maintained with strong community support.
+* **Reinforcement learning for robotics:** [MuJoCo](https://github.com/google-deepmind/mujoco) (with MJX for GPU), [Bullet/PyBullet](https://github.com/bulletphysics/bullet3), or [DART](https://github.com/dartsim/dart) via [gym-dart](https://github.com/DartEnv/dart-env).
+* **Game-like real-time physics:** [Bullet](https://github.com/bulletphysics/bullet3), [PhysX](https://github.com/NVIDIA-Omniverse/PhysX), or [ReactPhysics3d](https://github.com/DanielChappuis/reactphysics3d).
+* **Biomechanical simulation:** [Simbody](https://github.com/simbody/simbody) (the engine behind OpenSim).
+* **Multi-physics (FEM, soft bodies, fluids):** [SOFA](https://github.com/sofa-framework/sofa) or [CHRONO](https://github.com/projectchrono/chrono).
+* **Differentiable simulation:** [Drake](https://github.com/RobotLocomotion/drake), [MuJoCo MJX](https://github.com/google-deepmind/mujoco), or [Tiny Differentiable Simulator](https://github.com/erwincoumans/tiny-differentiable-simulator).
+* **Lightweight rigid-body only:** [RBDL](https://github.com/rbdl/rbdl), [KDL](https://github.com/orocos/orocos_kinematics_dynamics), or [RBDyn](https://github.com/jrl-umi3218/RBDyn).
+* **Rust ecosystem:** [nphysics](https://github.com/dimforge/nphysics) (note: limited maintenance since 2021; consider [Rapier](https://rapier.rs/) as successor).
 
-### Code Quality
+## Benchmark Resources
 
-| Library  | Lines of Code | Lines of Comments | Coverage | Continuous Integration | Static Code Checker | Style Checker |
-|:--------:|:-------------:|:-----------------:|:--------:|:----------------------:|:-------------------:|:-------------:|
-| DART    | [75k](https://github.com/dartsim/dart/wiki/Project-Status) | [34k](https://github.com/dartsim/dart/wiki/Project-Status)  | [51%](https://coveralls.io/github/dartsim/dart) | Travis CI, Appveyor | None | None |
+### Benchmark Suites
 
-### Simulation Features
+* [scpeters/benchmark](https://github.com/scpeters/benchmark) — Benchmark comparisons of rigid-body dynamics simulators.
+* [leggedrobotics/SimBenchmark](https://leggedrobotics.github.io/SimBenchmark/) — Comprehensive benchmark for physics simulation in robotics. [[github](https://github.com/leggedrobotics/SimBenchmark)]
+* [IFToMM](http://iftomm-multibody.org/benchmark/) — Benchmark problems from the international multibody dynamics community.
+* [BPMD](https://grasp.robotics.cs.rpi.edu/bpmd/) — Benchmark Problems for Multibody Dynamics database.
 
-#### Families of Robots
+### Key Papers
 
-| Library  | UGV (ground mobile robot) | UAV (aerial robots) | AUV (underwater robots) | Robotic Arms | Robotic Hands (grasping simulation) | Humanoid Robots | Human Avatars |
-|:--------:|:--------------:|:---------------:|:-----------:|:---------------:|:----------:|:-----------:|:---------------------:|
-| DART     | Yes | No | No | Yes | Yes | Yes | No |
-
-#### Supported Kinematics/Dynamics Algorithms
-
-| Library  | Inverse Kinematics | Inverse Dynamics | Forward Dynamics | Hybrid Dynamics |
-|:--------:|:------------------:|:----------------:|:----------------:|:---------------:|
-| DART     | Yes | Yes | Yes  | Yes |
-
-#### Supported Joint Types
-
-| Library  | Revolute | Prismatic | Screw | Universal | [Cylindrical](https://en.wikipedia.org/wiki/Cylindrical_joint) | Ball | Euler | Translational | Planar | Free |
-|:--------:|:--------:|:---------:|:-----:|:---------:|:------------:|:----:|:-----:|:-------------:|:------:|:----:|
-| DART     | Yes | Yes  | Yes | Yes | [No](https://github.com/dartsim/dart/issues/721) | Yes | Yes | Yes | Yes | Yes |
-
-#### Supported Actuators
-
-| Library  | Kinematic Actuators | Force-controlled Actuators | Servos |
-|:--------:|:-------------------:|:--------------------------:|:------:|
-| DART     | Yes | Yes  | Yes |
-
-#### Supported Sensors
-
-| Library  | Odometry | IMU | Collision | GPS | Monocular Cameras | Stereo Cameras | Depth Cameras | 2D Laser Scanners | 3D Laser Scanners |
-|:--------:|:--------------:|:---------------:|:-----------:|:---------------:|:----------:|:-----------:|:---------------------:|:------------:|:----------:|
-| DART     | No | No | No | No | No | No | No | No | No |
-
-### Benchmark
-
-* [scpeters/benchmark](https://github.com/scpeters/benchmark) - Benchmark comparisons of rigid-body dynamics simulators
-* [leggedrobotics/SimBenchmark](https://leggedrobotics.github.io/SimBenchmark/) - [[github](https://github.com/leggedrobotics/SimBenchmark)]
-
-#### Problems
-
-* [IFToMM](http://iftomm-multibody.org/benchmark/) - A tool for the international multibody dynamics community to propose, solve, and refer to a collection of benchmark problems.
-* [BPMD](https://grasp.robotics.cs.rpi.edu/bpmd/) - Benchmark Problems for Multibody Dynamics (BPMD) Database.
-
-#### Papers
-
-* M. Torres-Torriti et al. [Survey and comparative study of free simulation software for mobile robots](http://journals.cambridge.org/action/displayAbstract?fromPage=online&aid=10215708&fileId=S0263574714001866). Robotica 2016.
 * T. Erez et al. [Simulation tools for model-based robotics: comparison of Bullet, Havok, MuJoCo, ODE, and PhysX](http://ieeexplore.ieee.org/xpls/abs_all.jsp?arnumber=7139807). ICRA 2015. ([pdf](https://homes.cs.washington.edu/~todorov/papers/ErezICRA15.pdf))
-* Y. Lu et al. Comparison of Multibody Dynamics Solver Performance: Synthetic versus Realistic Data. ASME IDETC/CIEC 2015.
+* M. Torres-Torriti et al. [Survey and comparative study of free simulation software for mobile robots](http://journals.cambridge.org/action/displayAbstract?fromPage=online&aid=10215708&fileId=S0263574714001866). Robotica 2016.
 * S. Ivaldi et al. [Tools for simulating humanoid robot dynamics: a survey based on user feedback](http://ieeexplore.ieee.org/xpl/articleDetails.jsp?arnumber=7041462). Humanoids 2014. ([pdf](http://arxiv.org/pdf/1402.7050.pdf))
+* Y. Lu et al. Comparison of Multibody Dynamics Solver Performance: Synthetic versus Realistic Data. ASME IDETC/CIEC 2015.
 
-#### Articles
+### Articles
 
-* [9 open source robotics projects](https://opensource.com/life/16/4/open-source-robotics-projects) by [Jason Baker](https://opensource.com/users/jason-baker)
-* [Comparison of Rigid Body Dynamic Simulators for Robotic Simulation in Gazebo](http://www.osrfoundation.org/wordpress2/wp-content/uploads/2015/04/roscon2014_scpeters.pdf) by Steven Peters and John Hsu
-* [Open Source Physics Engines](http://www.tapirgames.com/blog/open-source-physics-engines) by [Tapir Liu](https://twitter.com/TapirLiu)
-* Survey of multibody dynamics software maintained by Ying Lu
+* [Comparison of Rigid Body Dynamic Simulators for Robotic Simulation in Gazebo](http://www.osrfoundation.org/wordpress2/wp-content/uploads/2015/04/roscon2014_scpeters.pdf) — Steven Peters and John Hsu.
 * [Wikipedia: Robotics simulator](https://en.wikipedia.org/wiki/Robotics_simulator#Simulators)
 
-## [Simulators](#comparisons)
-
-* [Gazebo](https://gazebosim.org/) ([bitbucket](https://bitbucket.org/osrf/gazebo)) - A dynamic multi-robot simulator.
-* [GraspIt!](http://graspit-simulator.github.io/) ([github](https://github.com/graspit-simulator/graspit)) - A simulator for grasping research that can accommodate arbitrary hand and robot designs developed by [the Columbia University Robotics Group](http://www.cs.columbia.edu/robotics/)
-* [MORSE](http://morse-simulator.github.io/) ([github](https://github.com/morse-simulator/morse)) - The Modular OpenRobots Simulation Engine.
-* [V-REP](https://www.coppeliarobotics.com/) - Virtual robot experimentation platform.
-
-### General Information
-
-| Library  | Developer(s) | Latest Release | Platform Supported | License | Github :star: |
-|:--------:| ------------ | -------------- | ------------------ | ------- |:------------:|
-| Gazebo   | [OSRF](http://www.osrfoundation.org/) | [7.1.0 (2016-04-08)](https://gazebosim.org/docs) | Linux, Mac, Windows | Apache 2.0 | N/A |
-| MORSE    | [LAAS-CNRS and many](http://www.openrobots.org/morse/doc/latest/credits.html) | 1.4 (2016-02-08) | Linux | BSD 3-Clause | 153 |
-| V-REP    | [Coppelia Robotics](https://www.coppeliarobotics.com/) | [3.3.0 (2016-02-19)](https://www.coppeliarobotics.com/) | Linux, Mac, Windows | [Commercial / Free educational](https://www.coppeliarobotics.com/) | N/A |
-:star: updated Apr 19, 2016
-
-### Papers
-
-* A. Staranowicz, G. L. Mariottini, A Survey and Comparison of Commercial and Open-Source Robotic Simulator Software, PETRA 2011.
-
-## [Contributing](#comparison)
+## [Contributing](#comparisons)
 
 Contributions are very welcome! Please read the [contribution guidelines](https://github.com/jslee02/awesome-robotics-libraries/blob/main/CONTRIBUTING.md) first. Also, please feel free to report any error.
 
-## [License](#comparison)
+## [License](#comparisons)
 
 [![CC0](https://licensebuttons.net/p/zero/1.0/88x31.png)](http://creativecommons.org/publicdomain/zero/1.0/)

--- a/README.md
+++ b/README.md
@@ -31,38 +31,38 @@ _Simulation environments for testing and developing robotic systems._
 
 ###### Free or Open Source
 
-* [AI2-THOR](https://ai2thor.allenai.org/) - Python framework with a Unity backend, providing interaction, navigation, and manipulation support for household based robotic agents. [[github](https://github.com/allenai/ai2thor) ![AI2-THOR](https://img.shields.io/github/stars/allenai/ai2thor.svg?style=flat&label=Star&maxAge=86400)]
-* AirSim - Simulator based on Unreal Engine for autonomous vehicles. [[github](https://github.com/Microsoft/AirSim) ![AirSim](https://img.shields.io/github/stars/Microsoft/AirSim.svg?style=flat&label=Star&maxAge=86400)]
-* [ARGoS](https://www.argos-sim.info/) - Physics-based simulator designed to simulate large-scale robot swarms. [[github](https://github.com/ilpincy/argos3) ![ARGoS](https://img.shields.io/github/stars/ilpincy/argos3.svg?style=flat&label=Star&maxAge=86400)]
-* [ARTE](http://arvc.umh.es/arte/index_en.html) - Matlab toolbox focussed on robotic manipulators. [[github](https://github.com/4rtur1t0/ARTE) ![ARTE](https://img.shields.io/github/stars/4rtur1t0/ARTE.svg?style=flat&label=Star&maxAge=86400)]
-* [AVIS Engine](https://avisengine.com) - Autonomous Vehicles Intelligent simulation software, A Fast and robust simulator software for Autonomous vehicle development. [[github](https://github.com/AvisEngine/AVIS-Engine-Python-API) ![AVIS Engine](https://img.shields.io/github/stars/AvisEngine/AVIS-Engine-Python-API.svg?style=flat&label=Star&maxAge=86400)]
-* [CARLA](https://carla.org/) - Open-source simulator for autonomous driving research. [[github](https://github.com/carla-simulator/carla) ![CARLA](https://img.shields.io/github/stars/carla-simulator/carla.svg?style=flat&label=Star&maxAge=86400)]
-* [CoppeliaSim](https://www.coppeliarobotics.com/) - Formaly V-REP. Virtual robot experimentation platform. [[github](https://github.com/CoppeliaRobotics/CoppeliaSimLib) ![CoppeliaSim](https://img.shields.io/github/stars/CoppeliaRobotics/CoppeliaSimLib.svg?style=flat&label=Star&maxAge=86400)]
-* [Gazebo](https://gazebosim.org/) - Dynamic multi-robot simulator. [[github](https://github.com/gazebosim/gazebo-classic) ![Gazebo](https://img.shields.io/github/stars/gazebosim/gazebo-classic.svg?style=flat&label=Star&maxAge=86400)]
-* [GraspIt!](http://graspit-simulator.github.io/) - Simulator for grasping research that can accommodate arbitrary hand and robot designs. [[github](https://github.com/graspit-simulator/graspit) ![GraspIt!](https://img.shields.io/github/stars/graspit-simulator/graspit.svg?style=flat&label=Star&maxAge=86400)]
-* [Habitat-Sim](https://aihabitat.org/) - Simulation platform for research in embodied artificial intelligence. [[github](https://github.com/facebookresearch/habitat-sim) ![Habitat-Sim](https://img.shields.io/github/stars/facebookresearch/habitat-sim.svg?style=flat&label=Star&maxAge=86400)]
-* [Hexapod Robot Simulator](https://hexapod.netlify.app/) - Open-source hexapod robot inverse kinematics and gaits visualizer. [[github](https://github.com/mithi/hexapod) ![Hexapod Robot Simulator](https://img.shields.io/github/stars/mithi/hexapod.svg?style=flat&label=Star&maxAge=86400)]
-* [Gazebo Sim](https://gazebosim.org/) - Open source robotics simulator (formerly Ignition Gazebo). [[github](https://github.com/gazebosim/gz-sim) ![Gazebo Sim](https://img.shields.io/github/stars/gazebosim/gz-sim.svg?style=flat&label=Star&maxAge=86400)]
+* [AI2-THOR](https://ai2thor.allenai.org/) - Python framework with a Unity backend, providing interaction, navigation, and manipulation support for household based robotic agents. [[github](https://github.com/allenai/ai2thor) ⭐ 1.7k]
+* AirSim - Simulator based on Unreal Engine for autonomous vehicles. [[github](https://github.com/Microsoft/AirSim) ⭐ 17.9k]
+* [ARGoS](https://www.argos-sim.info/) - Physics-based simulator designed to simulate large-scale robot swarms. [[github](https://github.com/ilpincy/argos3) ⭐ 301]
+* [ARTE](http://arvc.umh.es/arte/index_en.html) - Matlab toolbox focussed on robotic manipulators. [[github](https://github.com/4rtur1t0/ARTE) ⭐ 101]
+* [AVIS Engine](https://avisengine.com) - Autonomous Vehicles Intelligent simulation software, A Fast and robust simulator software for Autonomous vehicle development. [[github](https://github.com/AvisEngine/AVIS-Engine-Python-API) ⭐ 21]
+* [CARLA](https://carla.org/) - Open-source simulator for autonomous driving research. [[github](https://github.com/carla-simulator/carla) ⭐ 13.5k]
+* [CoppeliaSim](https://www.coppeliarobotics.com/) - Formaly V-REP. Virtual robot experimentation platform. [[github](https://github.com/CoppeliaRobotics/CoppeliaSimLib) ⭐ 138]
+* [Gazebo](https://gazebosim.org/) - Dynamic multi-robot simulator. [[github](https://github.com/gazebosim/gazebo-classic) ⭐ 1.3k]
+* [Gazebo Sim](https://gazebosim.org/) - Open source robotics simulator (formerly Ignition Gazebo). [[github](https://github.com/gazebosim/gz-sim) ⭐ 1.2k]
+* [GraspIt!](http://graspit-simulator.github.io/) - Simulator for grasping research that can accommodate arbitrary hand and robot designs. [[github](https://github.com/graspit-simulator/graspit) ⭐ 207]
+* [Habitat-Sim](https://aihabitat.org/) - Simulation platform for research in embodied artificial intelligence. [[github](https://github.com/facebookresearch/habitat-sim) ⭐ 3.5k]
+* [Hexapod Robot Simulator](https://hexapod.netlify.app/) - Open-source hexapod robot inverse kinematics and gaits visualizer. [[github](https://github.com/mithi/hexapod) ⭐ 681]
 * [Isaac Sim](https://developer.nvidia.com/isaac/sim) - Nvidia's robotic simulation environment with GPU physics simulation and ray tracing.
-* [ManiSkill](https://github.com/haosulab/ManiSkill) - A robot simulation and behavior learning package powered by SAPIEN, with a strong focus on manipulation skills. [[github](https://github.com/haosulab/ManiSkill) ![ManiSkill](https://img.shields.io/github/stars/haosulab/ManiSkill.svg?style=flat&label=Star&maxAge=86400)]
-* [MORSE](http://morse-simulator.github.io/) - Modular open robots simulation engine. [[github](https://github.com/morse-simulator/morse) ![MORSE](https://img.shields.io/github/stars/morse-simulator/morse.svg?style=flat&label=Star&maxAge=86400)]
+* [ManiSkill](https://github.com/haosulab/ManiSkill) - A robot simulation and behavior learning package powered by SAPIEN, with a strong focus on manipulation skills. [[github](https://github.com/haosulab/ManiSkill) ⭐ 2.5k]
+* [MORSE](http://morse-simulator.github.io/) - Modular open robots simulation engine. [[github](https://github.com/morse-simulator/morse) ⭐ 370]
 * [Neurorobotics Platform](https://neurorobotics.net/) - Internet-accessible simulation of robots controlled by spiking neural networks. [[bitbucket](https://bitbucket.org/hbpneurorobotics/neurorobotics-platform)]
-* [PyBullet](https://docs.google.com/document/d/10sXEhzFRSnvFcl3XxNGhnD4N2SedqwdAvK3dsihxVUA/edit#heading=h.2ye70wns7io3) - An easy to use simulator for robotics and deep reinforcement learning. [[github](https://github.com/bulletphysics/bullet3) ![PyBullet](https://img.shields.io/github/stars/bulletphysics/bullet3.svg?style=flat&label=Star&maxAge=86400)]
-* [PyBullet_Industrial](https://pybullet-industrial.readthedocs.io/en/latest/) - A extension to PyBullet that allows for the simulation of various robotic manufacturing processes such as milling or 3D-printing. [[github](https://github.com/WBK-Robotics/pybullet_industrial) ![PyBullet_Industrial](https://img.shields.io/github/stars/WBK-Robotics/pybullet_industrial.svg?style=flat&label=Star&maxAge=86400)]
-* [Robot Gui](http://robot.glumb.de/) - A three.js based 3D robot interface. [[github](https://github.com/glumb/robot-gui) ![Robot Gui](https://img.shields.io/github/stars/glumb/robot-gui.svg?style=flat&label=Star&maxAge=86400)]
-* [SAPIEN](https://sapien.ucsd.edu) - A realistic and physics-rich simulated environment that hosts a large-scale set for articulated objects. [[github](https://github.com/haosulab/SAPIEN) ![SAPIEN](https://img.shields.io/github/stars/haosulab/SAPIEN.svg?style=flat&label=Star&maxAge=86400)]
+* [PyBullet](https://docs.google.com/document/d/10sXEhzFRSnvFcl3XxNGhnD4N2SedqwdAvK3dsihxVUA/edit#heading=h.2ye70wns7io3) - An easy to use simulator for robotics and deep reinforcement learning. [[github](https://github.com/bulletphysics/bullet3) ⭐ 14.2k]
+* [PyBullet_Industrial](https://pybullet-industrial.readthedocs.io/en/latest/) - A extension to PyBullet that allows for the simulation of various robotic manufacturing processes such as milling or 3D-printing. [[github](https://github.com/WBK-Robotics/pybullet_industrial) ⭐ 48]
+* [Robot Gui](http://robot.glumb.de/) - A three.js based 3D robot interface. [[github](https://github.com/glumb/robot-gui) ⭐ 384]
+* [SAPIEN](https://sapien.ucsd.edu) - A realistic and physics-rich simulated environment that hosts a large-scale set for articulated objects. [[github](https://github.com/haosulab/SAPIEN) ⭐ 714]
 * [Simbad](http://simbad.sourceforge.net/) - A Java 3D robot simulator, enables to write own robot controller with modifying environment using available sensors.
-* [Unity](https://unity.com/solutions/automotive-transportation-manufacturing/robotics) - Popular game engine that now offers open-source tools, tutorials, and resources for robotics simulation. [[github](https://github.com/Unity-Technologies/Unity-Robotics-Hub) ![Unity](https://img.shields.io/github/stars/Unity-Technologies/Unity-Robotics-Hub.svg?style=flat&label=Star&maxAge=86400)]
-* [Webots](http://www.cyberbotics.com/) - A complete development environment to model, program and simulate robots, vehicles and mechanical systems. [[github](https://github.com/cyberbotics/webots) ![Webots](https://img.shields.io/github/stars/cyberbotics/webots.svg?style=flat&label=Star&maxAge=86400)]
+* [Unity](https://unity.com/solutions/automotive-transportation-manufacturing/robotics) - Popular game engine that now offers open-source tools, tutorials, and resources for robotics simulation. [[github](https://github.com/Unity-Technologies/Unity-Robotics-Hub) ⭐ 2.5k]
+* [Webots](http://www.cyberbotics.com/) - A complete development environment to model, program and simulate robots, vehicles and mechanical systems. [[github](https://github.com/cyberbotics/webots) ⭐ 4.1k]
 
 ###### Commercial
 
 * [Actin Simulation](http://www.energid.com/) - Real-time robot simulation and control software.
 * [Artiminds](https://www.artiminds.com/) - Planning, programming, operation, analysis and optimization.
 * [Kineo](https://www.plm.automation.siemens.com/global/en/products/plm-components/kineo.html) - Path planning and trajectory optimization for industrial robotics and digital mock-up review applications.
+* [Robot Virtual Worlds](http://www.robotvirtualworlds.com/) - Virtual reality software for educational robotics.
 * [RobotDK](https://robodk.com/) - Simulation and OLP for robots.
 * [RobotStudio](https://www.abb.com/global/en/areas/robotics/products/software/robotstudio-suite) - ABB's simulation and offline programming software for robotics.
-* [Robot Virtual Worlds](http://www.robotvirtualworlds.com/) - Virtual reality software for educational robotics.
 * [Virtual Robotics Toolkit](https://www.virtualroboticstoolkit.com/) - 3D virtual environment for programming and testing robots.
 * [Visual Components](https://www.visualcomponents.com/) - 3D manufacturing simulation and visualization platform.
 
@@ -74,190 +74,161 @@ _Simulation environments for testing and developing robotic systems._
 
 ### [Dynamics Simulation](#contents)
 
-_Physics engines and rigid/soft body dynamics libraries for robotics._
+_Physics engines and rigid/soft body dynamics libraries. See also [Comparisons](COMPARISONS.md)._
 
-> :warning: The following table is not complete. Please feel free to report if you find something incorrect or missing.
-
-| Name | Models | Features | Languages | Licenses | Code | Popularity |
-|:----:| ------ | -------- | --------- | -------- | ---- | ---------- |
-| [ARCSim](http://graphics.berkeley.edu/resources/ARCSim/index.html) | soft | — | C++ | — |  |  |
-| [Bullet](https://pybullet.org/) | rigid, soft | ik, id, urdf, sdf | C++, Python | Zlib | [github](https://github.com/bulletphysics/bullet3) | ![Bullet](https://img.shields.io/github/stars/bulletphysics/bullet3.svg?style=flat&label=Star&maxAge=86400) |
-| [CHRONO::ENGINE](https://projectchrono.org/) | rigid, soft, granular, fluid | ik, urdf | C++, Python | BSD-3-Clause | [github](https://github.com/projectchrono/chrono) | ![CHRONO::ENGINE](https://img.shields.io/github/stars/projectchrono/chrono.svg?style=flat&label=Star&maxAge=86400) |
-| [DART](http://dartsim.github.io/) | rigid, soft | ik, id, plan, urdf, sdf | C++, Python | BSD-2-Clause | [github](https://github.com/dartsim/dart) | ![DART](https://img.shields.io/github/stars/dartsim/dart.svg?style=flat&label=Star&maxAge=86400) |
-| [Drake](https://drake.mit.edu/) | rigid, aero, fluid | ik, trj-opt, plan | C++, Matlab | BSD-3-Clause | [github](https://github.com/RobotLocomotion/drake) | ![Drake](https://img.shields.io/github/stars/RobotLocomotion/drake.svg?style=flat&label=Star&maxAge=86400) |
-| [Flex](https://developer.nvidia.com/flex) | rigid, soft, particle, fluid | — | C++ | — | [github](https://github.com/NVIDIAGameWorks/FleX) | ![Flex](https://img.shields.io/github/stars/NVIDIAGameWorks/FleX.svg?style=flat&label=Star&maxAge=86400) |
-| [FROST](https://ayonga.github.io/frost-dev/index.html) | rigid | — | MATLAB | BSD-3-Clause | [github](https://github.com/ayonga/frost-dev) | ![FROST](https://img.shields.io/github/stars/ayonga/frost-dev.svg?style=flat&label=Star&maxAge=86400) |
-| [IBDS](http://www.interactive-graphics.de/index.php/downloads/12-ibds) | rigid, particle | — | C++ | Zlib |  |  |
-| idyntree | rigid | id | C++, Python, Matlab, Lua | LGPL-2.1 | [github](https://github.com/gbionics/idyntree) | ![idyntree](https://img.shields.io/github/stars/gbionics/idyntree.svg?style=flat&label=Star&maxAge=86400) |
-| [KDL](https://www.orocos.org/kdl.html) | rigid | ik | C++ | LGPL-2.1 | [github](https://github.com/orocos/orocos_kinematics_dynamics) | ![KDL](https://img.shields.io/github/stars/orocos/orocos_kinematics_dynamics.svg?style=flat&label=Star&maxAge=86400) |
-| kindr | rigid | — | C++, Matlab | BSD-3-Clause | [github](https://github.com/ANYbotics/kindr) | ![kindr](https://img.shields.io/github/stars/ANYbotics/kindr.svg?style=flat&label=Star&maxAge=86400) |
-| [Klampt](https://klampt.org/) | — | — | C++, Python | BSD-3-Clause | [github](https://github.com/krishauser/Klampt) | ![Klampt](https://img.shields.io/github/stars/krishauser/Klampt.svg?style=flat&label=Star&maxAge=86400) |
-| [LibrePilot](http://www.librepilot.org/site/index.html) | uav, vehicles | — | C++ | GPL-3.0 | [bitbucket](https://bitbucket.org/librepilot/librepilot), [github](https://github.com/librepilot/LibrePilot) | ![LibrePilot](https://img.shields.io/github/stars/librepilot/LibrePilot.svg?style=flat&label=Star&maxAge=86400) |
-| [MARS](http://rock-simulation.github.io/mars/) | — | — | C++, Python | LGPL-3.0 | [github](https://github.com/rock-simulation/mars) | ![MARS](https://img.shields.io/github/stars/rock-simulation/mars.svg?style=flat&label=Star&maxAge=86400) |
-| [MBDyn](https://www.mbdyn.org/) | — | — | C++ | GPL-2.1 | [download](https://www.mbdyn.org/?Software_Download) |  |
-| [MBSim](https://www.mbsim-env.de/) | — | — | C++ | (not specified) | [github](https://github.com/mbsim-env/mbsim) | ![MBSim](https://img.shields.io/github/stars/mbsim-env/mbsim.svg?style=flat&label=Star&maxAge=86400) |
-| [MBSlib](http://www.sim.informatik.tu-darmstadt.de/res/sw/mbslib) | — | — | C++ | LGPL-3.0 | [github](https://github.com/SIM-TU-Darmstadt/mbslib) | ![MBSlib](https://img.shields.io/github/stars/SIM-TU-Darmstadt/mbslib.svg?style=flat&label=Star&maxAge=86400) |
-| metapod | — | — | C++ | LGPL-3.0 | [github](https://github.com/laas/metapod) | ![metapod](https://img.shields.io/github/stars/laas/metapod.svg?style=flat&label=Star&maxAge=86400) |
-| [Moby](http://physsim.sourceforge.net/index.html) | rigid | id | C++ | GPL-2.0 | [github](https://github.com/PositronicsLab/Moby) | ![Moby](https://img.shields.io/github/stars/PositronicsLab/Moby.svg?style=flat&label=Star&maxAge=86400) |
-| [mrpt](https://www.mrpt.org/) | vehicle | slam, cv | C++, Python, Matlab | BSD-3-Clause | [github](https://github.com/MRPT/mrpt) | ![mrpt](https://img.shields.io/github/stars/MRPT/mrpt.svg?style=flat&label=Star&maxAge=86400) |
-| [MuJoCo](https://mujoco.org/) | — | id | C++, Python | Apache-2.0 | [github](https://github.com/google-deepmind/mujoco) | ![MuJoCo](https://img.shields.io/github/stars/google-deepmind/mujoco.svg?style=flat&label=Star&maxAge=86400) |
-| [mvsim](http://wiki.ros.org/mvsim) | vehicle | — | C++ | GPL-3.0 | [github](https://github.com/MRPT/mvsim) | ![mvsim](https://img.shields.io/github/stars/MRPT/mvsim.svg?style=flat&label=Star&maxAge=86400) |
-| [Newton Dynamics](https://newtondynamics.com/) | — | — | C++ | Zlib | [github](https://github.com/MADEAPPS/newton-dynamics) | ![Newton Dynamics](https://img.shields.io/github/stars/MADEAPPS/newton-dynamics.svg?style=flat&label=Star&maxAge=86400) |
-| [nphysics](https://nphysics.org/) | — | — | Rust | BSD-3-Clause | [github](https://github.com/dimforge/nphysics) | ![nphysics](https://img.shields.io/github/stars/dimforge/nphysics.svg?style=flat&label=Star&maxAge=86400) |
-| [ODE](https://ode.org/) | rigid | — | C++ | LGPL-2.1 or BSD-3-Clause | [bitbucket](https://bitbucket.org/odedevs/ode) |  |
-| [OpenRAVE](https://www.openrave.org/) | — | — | C++, Python | LGPL-3.0 | [github](https://github.com/rdiankov/openrave) | ![OpenRAVE](https://img.shields.io/github/stars/rdiankov/openrave.svg?style=flat&label=Star&maxAge=86400) |
-| [pinocchio](https://stack-of-tasks.github.io/pinocchio/) | rigid | ik, id, urdf, analytical derivatives, code generation | C++, Python | BSD-2-Clause | [github](https://github.com/stack-of-tasks/pinocchio) | ![pinocchio](https://img.shields.io/github/stars/stack-of-tasks/pinocchio.svg?style=flat&label=Star&maxAge=86400) |
-| PositionBasedDynamics | — | — | C++ | MIT | [github](https://github.com/InteractiveComputerGraphics/PositionBasedDynamics) | ![PositionBasedDynamics](https://img.shields.io/github/stars/InteractiveComputerGraphics/PositionBasedDynamics.svg?style=flat&label=Star&maxAge=86400) |
-| [PhysX](https://nvidia-omniverse.github.io/PhysX/physx/5.5.0/index.html) | — | — | C++ | unknown | [github](https://github.com/NVIDIA-Omniverse/PhysX) | ![PhysX](https://img.shields.io/github/stars/NVIDIA-Omniverse/PhysX.svg?style=flat&label=Star&maxAge=86400) |
-| [PyDy](https://www.pydy.org/) | — | — | Python | BSD-3-Clause | [github](https://github.com/pydy/pydy) | ![PyDy](https://img.shields.io/github/stars/pydy/pydy.svg?style=flat&label=Star&maxAge=86400) |
-| [RBDL](https://rbdl.github.io/) | rigid | ik, id, urdf | C++, Python | Zlib | [github](https://github.com/rbdl/rbdl) | ![RBDL](https://img.shields.io/github/stars/rbdl/rbdl.svg?style=flat&label=Star&maxAge=86400) |
-| RBDyn | rigid | — | C++, Python | LGPL-3.0 | [github](https://github.com/jrl-umi3218/RBDyn) | ![RBDyn](https://img.shields.io/github/stars/jrl-umi3218/RBDyn.svg?style=flat&label=Star&maxAge=86400) |
-| [RaiSim](https://slides.com/jeminhwangbo/raisim-manual) | — | — | C++ | [custom](https://github.com/leggedrobotics/raisimLib/blob/a9e7673569997f35c0bc7eb5d11bc4fa188e863c/LICENSE.md) | [github](https://github.com/leggedrobotics/raisimLib) | ![RaiSim](https://img.shields.io/github/stars/leggedrobotics/raisimLib.svg?style=flat&label=Star&maxAge=86400) |
-| [ReactPhysics3d](https://www.reactphysics3d.com/) | — | — | C++ | Zlib | [github](https://github.com/DanielChappuis/reactphysics3d) | ![ReactPhysics3d](https://img.shields.io/github/stars/DanielChappuis/reactphysics3d.svg?style=flat&label=Star&maxAge=86400) |
-| RigidBodyDynamics.jl | rigid | — | Julia | MIT "Expat" | [github](https://github.com/JuliaRobotics/RigidBodyDynamics.jl) | ![RigidBodyDynamics.jl](https://img.shields.io/github/stars/JuliaRobotics/RigidBodyDynamics.jl.svg?style=flat&label=Star&maxAge=86400) |
-| [Rigs of Rods](https://www.rigsofrods.org/) | rigid, soft, vehicle | — | C++ | GPL-3.0 | [github](https://github.com/RigsOfRods/rigs-of-rods) | ![Rigs of Rods](https://img.shields.io/github/stars/RigsOfRods/rigs-of-rods.svg?style=flat&label=Star&maxAge=86400) |
-| [Robopy](https://adityadua24.github.io/robopy/) | — | — | Python 3 | MIT | [github](https://github.com/adityadua24/robopy) | ![Robopy](https://img.shields.io/github/stars/adityadua24/robopy.svg?style=flat&label=Star&maxAge=86400) |
-| [Robotics Library](https://www.roboticslibrary.org/) | — | — | C++ | GPL-3.0 or BSD-2-Clause | [github](https://github.com/roboticslibrary/rl) | ![Robotics Library](https://img.shields.io/github/stars/roboticslibrary/rl.svg?style=flat&label=Star&maxAge=86400) |
-| [RobWork](https://robwork.dk/) | — | — | C++ | Apache-2.0 | [gitlab](https://gitlab.com/sdurobotics/RobWork) |  |
-| [siconos](https://nonsmooth.gricad-pages.univ-grenoble-alpes.fr/siconos/) | — | — | C++, Python | Apache-2.0 | [github](https://github.com/siconos/siconos) | ![siconos](https://img.shields.io/github/stars/siconos/siconos.svg?style=flat&label=Star&maxAge=86400) |
-| [Simbody](https://simtk.org/home/simbody/) | rigid, molecules | id, urdf | C++ | Apache-2.0 | [github](https://github.com/simbody/simbody) | ![Simbody](https://img.shields.io/github/stars/simbody/simbody.svg?style=flat&label=Star&maxAge=86400) |
-| [SOFA](https://www.sofa-framework.org/) | rigid, soft, medical | — | C++ | LGPL-2.1 | [github](https://github.com/sofa-framework/sofa) | ![SOFA](https://img.shields.io/github/stars/sofa-framework/sofa.svg?style=flat&label=Star&maxAge=86400) |
-| Tiny Differentiable Simulator | rigid | — | C++, Python | Apache-2.0 | [github](https://github.com/erwincoumans/tiny-differentiable-simulator) | ![Tiny Differentiable Simulator](https://img.shields.io/github/stars/erwincoumans/tiny-differentiable-simulator.svg?style=flat&label=Star&maxAge=86400) |
-| [trep](http://murpheylab.github.io/trep/) | rigid | dm, trj-opt | C, Python | GPL-3.0 | [github](https://github.com/MurpheyLab/trep) | ![trep](https://img.shields.io/github/stars/MurpheyLab/trep.svg?style=flat&label=Star&maxAge=86400) |
-| qu3e | rigid | — | C++ | Zlib | [github](https://github.com/RandyGaul/qu3e) | ![qu3e](https://img.shields.io/github/stars/RandyGaul/qu3e.svg?style=flat&label=Star&maxAge=86400) |
-
-For simplicity, shortened names are used to represent the supported models and features as
-
-* Supported Models
-  * rigid: rigid bodies
-  * soft: soft bodies
-  * aero: aerodynamics
-  * granular: granular materials (like sand)
-  * fluid: fluid dynamics
-  * vehicles
-  * uav: unmanned aerial vehicles (like drones)
-  * medical
-  * molecules
-  * parallel: parallel mechanism (like Stewart platform)
-
-* Features on Simulation, Analysis, Planning, Control Design
-  * dm: [discrete mechanics](https://www.cambridge.org/core/journals/acta-numerica/article/div-classtitlediscrete-mechanics-and-variational-integratorsdiv/C8F45478A9290DEC24E63BB7FBE3CEB5)
-  * ik: [inverse kinematics](https://en.wikipedia.org/wiki/Inverse_kinematics) solvers (please find IK specialized packages in [this list](#inverse-kinematics))
-  * id: [inverse dynamics](https://en.wikipedia.org/wiki/Inverse_dynamics)
-  * slam: [simultaneous localization and mapping](https://en.wikipedia.org/wiki/Simultaneous_localization_and_mapping)
-  * trj-opt: trajectory optimization
-  * plan: motion planning algorithms
-  * cv: computer vision
-  * urdf: [urdf](http://wiki.ros.org/urdf) parser
-  * sdf: [sdf](http://sdformat.org/) parser
+* [ARCSim](http://graphics.berkeley.edu/resources/ARCSim/index.html) - Adaptive remeshing cloth and shell simulator for thin deformable objects.
+* [Bullet](https://pybullet.org/) - Real-time physics simulation for games, visual effects, and robotics. [[github](https://github.com/bulletphysics/bullet3) ⭐ 14.2k]
+* [CHRONO::ENGINE](https://projectchrono.org/) - Multi-physics simulation of rigid and flexible bodies, granular, and fluid systems. [[github](https://github.com/projectchrono/chrono) ⭐ 2.7k]
+* [DART](http://dartsim.github.io/) - Dynamic Animation and Robotics Toolkit for multibody simulation and planning. [[github](https://github.com/dartsim/dart) ⭐ 1.1k]
+* [Drake](https://drake.mit.edu/) - Planning, control, and analysis toolbox for nonlinear dynamical systems. [[github](https://github.com/RobotLocomotion/drake) ⭐ 3.9k]
+* [Flex](https://developer.nvidia.com/flex) - GPU-based particle simulation for rigid bodies, fluids, and deformables. [[github](https://github.com/NVIDIAGameWorks/FleX) ⭐ 787]
+* [FROST](https://ayonga.github.io/frost-dev/index.html) - Fast Robot Optimization and Simulation Toolkit for hybrid dynamical systems in MATLAB. [[github](https://github.com/ayonga/frost-dev) ⭐ 169]
+* [IBDS](http://www.interactive-graphics.de/index.php/downloads/12-ibds) - Impulse-based dynamics simulation for rigid bodies and particle systems.
+* idyntree - Library for estimation and whole-body dynamics of floating-base robots. [[github](https://github.com/gbionics/idyntree) ⭐ 223]
+* [KDL](https://www.orocos.org/kdl.html) - Orocos Kinematics and Dynamics Library for kinematic chains. [[github](https://github.com/orocos/orocos_kinematics_dynamics) ⭐ 857]
+* kindr - Kinematics and dynamics library for rigid body transformations. [[github](https://github.com/ANYbotics/kindr) ⭐ 607]
+* [Klampt](https://klampt.org/) - Robot planning, control, and simulation with visualization support. [[github](https://github.com/krishauser/Klampt) ⭐ 427]
+* [LibrePilot](http://www.librepilot.org/site/index.html) - Open-source autopilot for UAVs and other autonomous vehicles. [[github](https://github.com/librepilot/LibrePilot) ⭐ 348]
+* [MARS](http://rock-simulation.github.io/mars/) - Machina Arte Robotum Simulans — a cross-platform simulation environment. [[github](https://github.com/rock-simulation/mars) ⭐ 67]
+* [MBDyn](https://www.mbdyn.org/) - General-purpose multibody dynamics analysis software.
+* [MBSim](https://www.mbsim-env.de/) - Multi-body simulation environment for flexible and rigid systems. [[github](https://github.com/mbsim-env/mbsim) ⭐ 51]
+* [MBSlib](http://www.sim.informatik.tu-darmstadt.de/res/sw/mbslib) - Lightweight multibody system dynamics library. [[github](https://github.com/SIM-TU-Darmstadt/mbslib) ⭐ 11]
+* metapod - Template-based robot dynamics library using spatial algebra. [[github](https://github.com/laas/metapod) ⭐ 14]
+* [Moby](http://physsim.sourceforge.net/index.html) - Multi-body dynamics simulation for rigid bodies with contact. [[github](https://github.com/PositronicsLab/Moby) ⭐ 37]
+* [mrpt](https://www.mrpt.org/) - Mobile Robot Programming Toolkit for SLAM, navigation, and computer vision. [[github](https://github.com/MRPT/mrpt) ⭐ 2.1k]
+* [MuJoCo](https://mujoco.org/) - Multi-joint dynamics with contact for physics-based simulation and control. [[github](https://github.com/google-deepmind/mujoco) ⭐ 11.9k]
+* [mvsim](http://wiki.ros.org/mvsim) - Lightweight multi-vehicle 2D simulator with ROS integration. [[github](https://github.com/MRPT/mvsim) ⭐ 359]
+* [Newton Dynamics](https://newtondynamics.com/) - Real-time physics engine for rigid body simulation. [[github](https://github.com/MADEAPPS/newton-dynamics) ⭐ 1k]
+* [nphysics](https://nphysics.org/) - 2D and 3D rigid body physics engine written in Rust. [[github](https://github.com/dimforge/nphysics) ⭐ 1.6k]
+* [ODE](https://ode.org/) - Open Dynamics Engine for simulating rigid body dynamics. [[bitbucket](https://bitbucket.org/odedevs/ode)]
+* [OpenRAVE](https://www.openrave.org/) - Open Robotics Automation Virtual Environment for planning and simulation. [[github](https://github.com/rdiankov/openrave) ⭐ 798]
+* [PhysX](https://nvidia-omniverse.github.io/PhysX/physx/5.5.0/index.html) - NVIDIA physics engine for real-time rigid body and vehicle simulation. [[github](https://github.com/NVIDIA-Omniverse/PhysX) ⭐ 4.4k]
+* [pinocchio](https://stack-of-tasks.github.io/pinocchio/) - Fast and flexible algorithms for rigid-body dynamics with analytical derivatives. [[github](https://github.com/stack-of-tasks/pinocchio) ⭐ 3.1k]
+* PositionBasedDynamics - Position-based methods for simulating deformable objects and fluids. [[github](https://github.com/InteractiveComputerGraphics/PositionBasedDynamics) ⭐ 2.2k]
+* [PyDy](https://www.pydy.org/) - Multibody dynamics analysis with symbolic Python using SymPy. [[github](https://github.com/pydy/pydy) ⭐ 405]
+* qu3e - Lightweight 3D physics engine for rigid body dynamics. [[github](https://github.com/RandyGaul/qu3e) ⭐ 974]
+* [RaiSim](https://slides.com/jeminhwangbo/raisim-manual) - Cross-platform physics engine for robotics and reinforcement learning. [[github](https://github.com/leggedrobotics/raisimLib) ⭐ 329]
+* [RBDL](https://rbdl.github.io/) - Rigid Body Dynamics Library based on Featherstone algorithms. [[github](https://github.com/rbdl/rbdl) ⭐ 683]
+* RBDyn - Rigid body dynamics algorithms using spatial algebra with Eigen. [[github](https://github.com/jrl-umi3218/RBDyn) ⭐ 211]
+* [ReactPhysics3d](https://www.reactphysics3d.com/) - Open-source 3D physics engine for rigid body simulation and collision detection. [[github](https://github.com/DanielChappuis/reactphysics3d) ⭐ 1.7k]
+* RigidBodyDynamics.jl - Julia library for rigid body dynamics algorithms. [[github](https://github.com/JuliaRobotics/RigidBodyDynamics.jl) ⭐ 307]
+* [Rigs of Rods](https://www.rigsofrods.org/) - Soft-body vehicle simulator using beam physics. [[github](https://github.com/RigsOfRods/rigs-of-rods) ⭐ 1.1k]
+* [Robopy](https://adityadua24.github.io/robopy/) - Python robotics toolbox inspired by Peter Corke's Robotics Toolbox. [[github](https://github.com/adityadua24/robopy) ⭐ 228]
+* [Robotics Library](https://www.roboticslibrary.org/) - Self-contained C++ library for robot kinematics, planning, and control. [[github](https://github.com/roboticslibrary/rl) ⭐ 1.2k]
+* [RobWork](https://robwork.dk/) - Framework for simulation and control of robot systems. [[gitlab](https://gitlab.com/sdurobotics/RobWork)]
+* [siconos](https://nonsmooth.gricad-pages.univ-grenoble-alpes.fr/siconos/) - Nonsmooth dynamical systems modeling and simulation platform. [[github](https://github.com/siconos/siconos) ⭐ 182]
+* [Simbody](https://simtk.org/home/simbody/) - Multibody dynamics library for biomechanical and mechanical systems. [[github](https://github.com/simbody/simbody) ⭐ 2.5k]
+* [SOFA](https://www.sofa-framework.org/) - Simulation Open Framework Architecture for medical and physics simulation. [[github](https://github.com/sofa-framework/sofa) ⭐ 1.1k]
+* Tiny Differentiable Simulator - Header-only differentiable physics engine for robotics. [[github](https://github.com/erwincoumans/tiny-differentiable-simulator) ⭐ 1.3k]
+* [trep](http://murpheylab.github.io/trep/) - Simulation and optimal control using variational integrators. [[github](https://github.com/MurpheyLab/trep) ⭐ 20]
 
 ### [Inverse Kinematics](#contents)
 
 _Libraries for computing joint configurations from end-effector poses._
 
-  * IKBT - A python package to solve robot arm inverse kinematics in symbolic form. [[github](https://github.com/uw-biorobotics/IKBT) ![IKBT](https://img.shields.io/github/stars/uw-biorobotics/IKBT.svg?style=flat&label=Star&maxAge=86400)]
-  * Kinpy - A simple pure python package to solve inverse kinematics. [[github](https://github.com/neka-nat/kinpy) ![Kinpy](https://img.shields.io/github/stars/neka-nat/kinpy.svg?style=flat&label=Star&maxAge=86400)]
-  * Lively - A highly configurable toolkit for commanding robots in mixed modalities. [[github](https://github.com/Wisc-HCI/lively) ![Lively](https://img.shields.io/github/stars/Wisc-HCI/lively.svg?style=flat&label=Star&maxAge=86400)]
-  * RelaxedIK - Real-time Synthesis of Accurate and Feasible Robot Arm Motion. [[github](https://github.com/uwgraphics/relaxed_ik) ![RelaxedIK](https://img.shields.io/github/stars/uwgraphics/relaxed_ik.svg?style=flat&label=Star&maxAge=86400)]
-  * [Trip](https://trip-kinematics.readthedocs.io/en/main/index.html) - A python package that solves inverse kinematics of parallel-, serial- or hybrid-robots. [[github](https://github.com/TriPed-Robot/trip_kinematics) ![Trip](https://img.shields.io/github/stars/TriPed-Robot/trip_kinematics.svg?style=flat&label=Star&maxAge=86400)]
+  * IKBT - A python package to solve robot arm inverse kinematics in symbolic form. [[github](https://github.com/uw-biorobotics/IKBT) ⭐ 215]
+  * Kinpy - A simple pure python package to solve inverse kinematics. [[github](https://github.com/neka-nat/kinpy) ⭐ 179]
+  * Lively - A highly configurable toolkit for commanding robots in mixed modalities. [[github](https://github.com/Wisc-HCI/lively) ⭐ 7]
+  * RelaxedIK - Real-time Synthesis of Accurate and Feasible Robot Arm Motion. [[github](https://github.com/uwgraphics/relaxed_ik) ⭐ 235]
+  * [Trip](https://trip-kinematics.readthedocs.io/en/main/index.html) - A python package that solves inverse kinematics of parallel-, serial- or hybrid-robots. [[github](https://github.com/TriPed-Robot/trip_kinematics) ⭐ 44]
 
 ### [Machine Learning](#contents)
 
 _Machine learning frameworks and tools applied to robotics._
 
-* [AllenAct](https://allenact.org/) - Python/PyTorch-based Research Framework for Embodied AI. [[github](https://github.com/allenai/allenact) ![AllenAct](https://img.shields.io/github/stars/allenai/allenact.svg?style=flat&label=Star&maxAge=86400)]
-* Any4LeRobot - A collection of utilities and tools for LeRobot. [[github](https://github.com/Tavish9/any4lerobot) ![Any4LeRobot](https://img.shields.io/github/stars/Tavish9/any4lerobot.svg?style=flat&label=Star&maxAge=86400)]
-* DLL - Deep Learning Library (DLL) for C++. [[github](https://github.com/wichtounet/dll) ![DLL](https://img.shields.io/github/stars/wichtounet/dll.svg?style=flat&label=Star&maxAge=86400)]
-* [DyNet](https://dynet.readthedocs.io/en/latest/) - The Dynamic Neural Network Toolkit. [[github](https://github.com/clab/dynet) ![DyNet](https://img.shields.io/github/stars/clab/dynet.svg?style=flat&label=Star&maxAge=86400)]
-* [Fido](http://fidoproject.github.io/) - Lightweight C++ machine learning library for embedded electronics and robotics. [[github](https://github.com/FidoProject/Fido) ![Fido](https://img.shields.io/github/stars/FidoProject/Fido.svg?style=flat&label=Star&maxAge=86400)]
-* [Ivy](https://lets-unify.ai/) - Unified Machine Learning Framework. [[github](https://github.com/ivy-llc/ivy) ![Ivy](https://img.shields.io/github/stars/ivy-llc/ivy.svg?style=flat&label=Star&maxAge=86400)]
-* LeRobot - State-of-the-art approaches, pretrained models, datasets, and simulation environments for real-world robotics in PyTorch. [[github](https://github.com/huggingface/lerobot) ![LeRobot](https://img.shields.io/github/stars/huggingface/lerobot.svg?style=flat&label=Star&maxAge=86400)]
-* [LeRobot Episode Scoring Toolkit](https://github.com/RoboticsData/score_lerobot_episodes) - One-click tool to score, filter, and export higher-quality LeRobot datasets. [[github](https://github.com/RoboticsData/score_lerobot_episodes) ![LeRobot Episode Scoring Toolkit](https://img.shields.io/github/stars/RoboticsData/score_lerobot_episodes.svg?style=flat&label=Star&maxAge=86400)]
-* MiniDNN - A header-only C++ library for deep neural networks. [[github](https://github.com/yixuan/MiniDNN) ![MiniDNN](https://img.shields.io/github/stars/yixuan/MiniDNN.svg?style=flat&label=Star&maxAge=86400)]
-* [mlpack](https://www.mlpack.org/) - Scalable C++ machine learning library. [[github](https://github.com/mlpack/mlpack) ![mlpack](https://img.shields.io/github/stars/mlpack/mlpack.svg?style=flat&label=Star&maxAge=86400)]
-* [Gymnasium](https://gymnasium.farama.org/) - Developing and comparing reinforcement learning algorithms. [[github](https://github.com/Farama-Foundation/Gymnasium) ![Gymnasium](https://img.shields.io/github/stars/Farama-Foundation/Gymnasium.svg?style=flat&label=Star&maxAge=86400)]
-  * gym-dart - OpenAI Gym environments using the DART physics engine. [[github](https://github.com/DartEnv/dart-env) ![gym-dart](https://img.shields.io/github/stars/DartEnv/dart-env.svg?style=flat&label=Star&maxAge=86400)]
-  * gym-gazebo - OpenAI Gym environments for the Gazebo simulator. [[github](https://github.com/erlerobot/gym-gazebo) ![gym-gazebo](https://img.shields.io/github/stars/erlerobot/gym-gazebo.svg?style=flat&label=Star&maxAge=86400)]
-* RLLib - Temporal-difference learning algorithms in reinforcement learning. [[github](https://github.com/samindaa/RLLib) ![RLLib](https://img.shields.io/github/stars/samindaa/RLLib.svg?style=flat&label=Star&maxAge=86400)]
-* [robosuite](https://robosuite.ai) - A modular simulation framework and benchmark for robot learning. [[github](https://github.com/ARISE-Initiative/robosuite) ![robosuite](https://img.shields.io/github/stars/ARISE-Initiative/robosuite.svg?style=flat&label=Star&maxAge=86400)]
-* [tiny-dnn](http://tiny-dnn.readthedocs.io/en/latest/) - Header only, dependency-free deep learning framework in C++14. [[github](https://github.com/tiny-dnn/tiny-dnn) ![tiny-dnn](https://img.shields.io/github/stars/tiny-dnn/tiny-dnn.svg?style=flat&label=Star&maxAge=86400)]
+* [AllenAct](https://allenact.org/) - Python/PyTorch-based Research Framework for Embodied AI. [[github](https://github.com/allenai/allenact) ⭐ 376]
+* Any4LeRobot - A collection of utilities and tools for LeRobot. [[github](https://github.com/Tavish9/any4lerobot) ⭐ 838]
+* DLL - Deep Learning Library (DLL) for C++. [[github](https://github.com/wichtounet/dll) ⭐ 687]
+* [DyNet](https://dynet.readthedocs.io/en/latest/) - The Dynamic Neural Network Toolkit. [[github](https://github.com/clab/dynet) ⭐ 3.4k]
+* [Fido](http://fidoproject.github.io/) - Lightweight C++ machine learning library for embedded electronics and robotics. [[github](https://github.com/FidoProject/Fido) ⭐ 462]
+* [Gymnasium](https://gymnasium.farama.org/) - Developing and comparing reinforcement learning algorithms. [[github](https://github.com/Farama-Foundation/Gymnasium) ⭐ 11.2k]
+  * gym-dart - OpenAI Gym environments using the DART physics engine. [[github](https://github.com/DartEnv/dart-env) ⭐ 141]
+  * gym-gazebo - OpenAI Gym environments for the Gazebo simulator. [[github](https://github.com/erlerobot/gym-gazebo) ⭐ 845]
+* [Ivy](https://lets-unify.ai/) - Unified Machine Learning Framework. [[github](https://github.com/ivy-llc/ivy) ⭐ 14.2k]
+* LeRobot - State-of-the-art approaches, pretrained models, datasets, and simulation environments for real-world robotics in PyTorch. [[github](https://github.com/huggingface/lerobot) ⭐ 21.4k]
+* [LeRobot Episode Scoring Toolkit](https://github.com/RoboticsData/score_lerobot_episodes) - One-click tool to score, filter, and export higher-quality LeRobot datasets. [[github](https://github.com/RoboticsData/score_lerobot_episodes) ⭐ 48]
+* MiniDNN - A header-only C++ library for deep neural networks. [[github](https://github.com/yixuan/MiniDNN) ⭐ 431]
+* [mlpack](https://www.mlpack.org/) - Scalable C++ machine learning library. [[github](https://github.com/mlpack/mlpack) ⭐ 5.6k]
+* RLLib - Temporal-difference learning algorithms in reinforcement learning. [[github](https://github.com/samindaa/RLLib) ⭐ 208]
+* [robosuite](https://robosuite.ai) - A modular simulation framework and benchmark for robot learning. [[github](https://github.com/ARISE-Initiative/robosuite) ⭐ 2.2k]
+* [tiny-dnn](http://tiny-dnn.readthedocs.io/en/latest/) - Header only, dependency-free deep learning framework in C++14. [[github](https://github.com/tiny-dnn/tiny-dnn) ⭐ 6k]
 
 ### [Motion Planning and Control](#contents)
 
 _Libraries for robot motion planning, trajectory optimization, and control._
 
 
-* [AIKIDO](https://github.com/personalrobotics/aikido) - Solving robotic motion planning and decision making problems. [[github](https://github.com/personalrobotics/aikido) ![AIKIDO](https://img.shields.io/github/stars/personalrobotics/aikido.svg?style=flat&label=Star&maxAge=86400)]
-* Bioptim - Bioptim, a Python Framework for Musculoskeletal Optimal Control in Biomechanics. [[github](https://github.com/pyomeca/bioptim) ![Bioptim](https://img.shields.io/github/stars/pyomeca/bioptim.svg?style=flat&label=Star&maxAge=86400)]
+* [AIKIDO](https://github.com/personalrobotics/aikido) - Solving robotic motion planning and decision making problems. [[github](https://github.com/personalrobotics/aikido) ⭐ 228]
+* Bioptim - Bioptim, a Python Framework for Musculoskeletal Optimal Control in Biomechanics. [[github](https://github.com/pyomeca/bioptim) ⭐ 113]
+* [Control Toolbox](https://ethz-adrl.github.io/ct/) - Open-Source C++ Library for Robotics, Optimal and Model Predictive Control. [[github](https://github.com/ethz-adrl/control-toolbox) ⭐ 1.7k]
+* Crocoddyl - Optimal control library for robot control under contact sequence. [[github](https://github.com/loco-3d/crocoddyl) ⭐ 1.2k]
 * [CuiKSuite](http://www.iri.upc.edu/people/porta/Soft/CuikSuite2-Doc/html) - Applications to solve position analysis and path planning problems.
-* [cuRobo](https://curobo.org) - A CUDA accelerated library containing a suite of robotics algorithms that run significantly faster. [[github](https://github.com/nvlabs/curobo) ![cuRobo](https://img.shields.io/github/stars/nvlabs/curobo.svg?style=flat&label=Star&maxAge=86400)]
-* [Control Toolbox](https://ethz-adrl.github.io/ct/) - Open-Source C++ Library for Robotics, Optimal and Model Predictive Control. [[github](https://github.com/ethz-adrl/control-toolbox) ![Control Toolbox](https://img.shields.io/github/stars/ethz-adrl/control-toolbox.svg?style=flat&label=Star&maxAge=86400)]
-* Crocoddyl - Optimal control library for robot control under contact sequence. [[github](https://github.com/loco-3d/crocoddyl) ![Crocoddyl](https://img.shields.io/github/stars/loco-3d/crocoddyl.svg?style=flat&label=Star&maxAge=86400)]
-* Fields2Cover - Robust and efficient coverage paths for autonomous agricultural vehicles. [[github](https://github.com/fields2cover/fields2cover) ![Fields2Cover](https://img.shields.io/github/stars/fields2cover/fields2cover.svg?style=flat&label=Star&maxAge=86400)]
-* GPMP2 - Gaussian Process Motion Planner 2. [[github](https://github.com/gtrll/gpmp2) ![GPMP2](https://img.shields.io/github/stars/gtrll/gpmp2.svg?style=flat&label=Star&maxAge=86400)]
+* [cuRobo](https://curobo.org) - A CUDA accelerated library containing a suite of robotics algorithms that run significantly faster. [[github](https://github.com/nvlabs/curobo) ⭐ 1.3k]
+* Fields2Cover - Robust and efficient coverage paths for autonomous agricultural vehicles. [[github](https://github.com/fields2cover/fields2cover) ⭐ 745]
+* GPMP2 - Gaussian Process Motion Planner 2. [[github](https://github.com/gtrll/gpmp2) ⭐ 351]
 * [HPP](https://humanoid-path-planner.github.io/hpp-doc/) - Path planning for kinematic chains in environments cluttered with obstacles.
-* [MoveIt!](https://moveit.ai/) - Motion planning framework. [[github](https://github.com/moveit/moveit) ![MoveIt!](https://img.shields.io/github/stars/moveit/moveit.svg?style=flat&label=Star&maxAge=86400)]
-* [OMPL](https://ompl.kavrakilab.org/) - Open motion planning library. [[github](https://github.com/ompl/ompl) ![OMPL](https://img.shields.io/github/stars/ompl/ompl.svg?style=flat&label=Star&maxAge=86400)]
-* OCS2 - Efficient continuous and discrete time optimal control implementation. [[github](https://github.com/leggedrobotics/ocs2) ![OCS2](https://img.shields.io/github/stars/leggedrobotics/ocs2.svg?style=flat&label=Star&maxAge=86400)]
-* pymanoid - Humanoid robotics prototyping environment based on OpenRAVE. [[github](https://github.com/stephane-caron/pymanoid) ![pymanoid](https://img.shields.io/github/stars/stephane-caron/pymanoid.svg?style=flat&label=Star&maxAge=86400)]
-* ROS Behavior Tree - Behavior tree implementation for ROS-based robot task planning. [[github](https://github.com/miccol/ROS-Behavior-Tree) ![ROS Behavior Tree](https://img.shields.io/github/stars/miccol/ROS-Behavior-Tree.svg?style=flat&label=Star&maxAge=86400)]
-* [Ruckig](https://github.com/pantor/ruckig) - Real-time, time-optimal and jerk-constrained online trajectory generation. [[github](https://github.com/pantor/ruckig) ![Ruckig](https://img.shields.io/github/stars/pantor/ruckig.svg?style=flat&label=Star&maxAge=86400)]
-* [The Kautham Project](https://sir.upc.es/projects/kautham/) - A robot simulation toolkit for motion planning. [[github](https://github.com/iocroblab/kautham) ![The Kautham Project](https://img.shields.io/github/stars/iocroblab/kautham.svg?style=flat&label=Star&maxAge=86400)]
-* [TOPP-RA](https://hungpham2511.github.io/toppra/) - Time-parameterizing robot trajectories subject to kinematic and dynamic constraints. [[github](https://github.com/hungpham2511/toppra) ![TOPP-RA](https://img.shields.io/github/stars/hungpham2511/toppra.svg?style=flat&label=Star&maxAge=86400)]
-* [Ungar](https://github.com/fdevinc/ungar) - Expressive and efficient implementation of optimal control problems using template metaprogramming. [[github](https://github.com/fdevinc/ungar) ![Ungar](https://img.shields.io/github/stars/fdevinc/ungar.svg?style=flat&label=Star&maxAge=86400)]
+* [MoveIt!](https://moveit.ai/) - Motion planning framework. [[github](https://github.com/moveit/moveit) ⭐ 2k]
+* OCS2 - Efficient continuous and discrete time optimal control implementation. [[github](https://github.com/leggedrobotics/ocs2) ⭐ 1.3k]
+* [OMPL](https://ompl.kavrakilab.org/) - Open motion planning library. [[github](https://github.com/ompl/ompl) ⭐ 1.9k]
+* pymanoid - Humanoid robotics prototyping environment based on OpenRAVE. [[github](https://github.com/stephane-caron/pymanoid) ⭐ 232]
+* ROS Behavior Tree - Behavior tree implementation for ROS-based robot task planning. [[github](https://github.com/miccol/ROS-Behavior-Tree) ⭐ 362]
+* [Ruckig](https://github.com/pantor/ruckig) - Real-time, time-optimal and jerk-constrained online trajectory generation. [[github](https://github.com/pantor/ruckig) ⭐ 1.1k]
+* [The Kautham Project](https://sir.upc.es/projects/kautham/) - A robot simulation toolkit for motion planning. [[github](https://github.com/iocroblab/kautham) ⭐ 24]
+* [TOPP-RA](https://hungpham2511.github.io/toppra/) - Time-parameterizing robot trajectories subject to kinematic and dynamic constraints. [[github](https://github.com/hungpham2511/toppra) ⭐ 830]
+* [Ungar](https://github.com/fdevinc/ungar) - Expressive and efficient implementation of optimal control problems using template metaprogramming. [[github](https://github.com/fdevinc/ungar) ⭐ 109]
 
 ###### Motion Optimizer
 
-* TopiCo - Time-optimal Trajectory Generation and Control. [[github](https://github.com/AIS-Bonn/TopiCo) ![TopiCo](https://img.shields.io/github/stars/AIS-Bonn/TopiCo.svg?style=flat&label=Star&maxAge=86400)]
-* [towr](http://wiki.ros.org/towr) - A light-weight, Eigen-based C++ library for trajectory optimization for legged robots. [[github](https://github.com/ethz-adrl/towr) ![towr](https://img.shields.io/github/stars/ethz-adrl/towr.svg?style=flat&label=Star&maxAge=86400)]
-* TrajectoryOptimization - A fast trajectory optimization library written in Julia. [[github](https://github.com/RoboticExplorationLab/TrajectoryOptimization.jl) ![TrajectoryOptimization](https://img.shields.io/github/stars/RoboticExplorationLab/TrajectoryOptimization.jl.svg?style=flat&label=Star&maxAge=86400)]
-* [trajopt](http://rll.berkeley.edu/trajopt/doc/sphinx_build/html/) - Framework for generating robot trajectories by local optimization. [[github](https://github.com/joschu/trajopt) ![trajopt](https://img.shields.io/github/stars/joschu/trajopt.svg?style=flat&label=Star&maxAge=86400)]
+* TopiCo - Time-optimal Trajectory Generation and Control. [[github](https://github.com/AIS-Bonn/TopiCo) ⭐ 143]
+* [towr](http://wiki.ros.org/towr) - A light-weight, Eigen-based C++ library for trajectory optimization for legged robots. [[github](https://github.com/ethz-adrl/towr) ⭐ 1k]
+* TrajectoryOptimization - A fast trajectory optimization library written in Julia. [[github](https://github.com/RoboticExplorationLab/TrajectoryOptimization.jl) ⭐ 386]
+* [trajopt](http://rll.berkeley.edu/trajopt/doc/sphinx_build/html/) - Framework for generating robot trajectories by local optimization. [[github](https://github.com/joschu/trajopt) ⭐ 449]
 
 ###### Nearest Neighbor
 
-* [Cover-Tree](http://hunch.net/~jl/projects/cover_tree/cover_tree.html) - Cover tree data structure for quick k-nearest-neighbor search. [[github](https://github.com/DNCrane/Cover-Tree) ![Cover-Tree](https://img.shields.io/github/stars/DNCrane/Cover-Tree.svg?style=flat&label=Star&maxAge=86400)]
+* [Cover-Tree](http://hunch.net/~jl/projects/cover_tree/cover_tree.html) - Cover tree data structure for quick k-nearest-neighbor search. [[github](https://github.com/DNCrane/Cover-Tree) ⭐ 64]
   * [Faster cover trees](http://proceedings.mlr.press/v37/izbicki15.pdf) - by Mike Izbicki et al., ICML 2015.
-* [FLANN](http://www.cs.ubc.ca/research/flann/) - Fast Library for Approximate Nearest Neighbors. [[github](https://github.com/flann-lib/flann) ![FLANN](https://img.shields.io/github/stars/flann-lib/flann.svg?style=flat&label=Star&maxAge=86400)]
-* [nanoflann](http://www.cs.ubc.ca/research/flann/) - Nearest Neighbor search with KD-trees. [[github](https://github.com/jlblancoc/nanoflann) ![nanoflann](https://img.shields.io/github/stars/jlblancoc/nanoflann.svg?style=flat&label=Star&maxAge=86400)]
+* [FLANN](http://www.cs.ubc.ca/research/flann/) - Fast Library for Approximate Nearest Neighbors. [[github](https://github.com/flann-lib/flann) ⭐ 2.4k]
+* [nanoflann](http://www.cs.ubc.ca/research/flann/) - Nearest Neighbor search with KD-trees. [[github](https://github.com/jlblancoc/nanoflann) ⭐ 2.6k]
 
 ###### 3D Mapping
 
-* [libpointmatcher](http://libpointmatcher.readthedocs.io/en/latest/) - Iterative Closest Point library for 2-D/3-D mapping in Robotics. [[github](https://github.com/norlab-ulaval/libpointmatcher) ![libpointmatcher](https://img.shields.io/github/stars/norlab-ulaval/libpointmatcher.svg?style=flat&label=Star&maxAge=86400)]
-* Octree - Fast radius neighbor search with an Octree. [[github](https://github.com/jbehley/octree) ![Octree](https://img.shields.io/github/stars/jbehley/octree.svg?style=flat&label=Star&maxAge=86400)]
-* [OctoMap](http://octomap.github.io/) - Efficient Probabilistic 3D Mapping Framework Based on Octrees. [[github](https://github.com/OctoMap/octomap) ![OctoMap](https://img.shields.io/github/stars/OctoMap/octomap.svg?style=flat&label=Star&maxAge=86400)]
-* [PCL](https://pointclouds.org/) - 2D/3D image and point cloud processing. [[github](https://github.com/PointCloudLibrary/pcl) ![PCL](https://img.shields.io/github/stars/PointCloudLibrary/pcl.svg?style=flat&label=Star&maxAge=86400)]
-* Bonxai - Brutally fast, sparse, 3D Voxel Grid (formerly Treexy). [[github](https://github.com/facontidavide/Bonxai) ![Bonxai](https://img.shields.io/github/stars/facontidavide/Bonxai.svg?style=flat&label=Star&maxAge=86400)]
-* voxblox - Flexible voxel-based mapping focusing on truncated and Euclidean signed distance fields. [[github](https://github.com/ethz-asl/voxblox) ![voxblox](https://img.shields.io/github/stars/ethz-asl/voxblox.svg?style=flat&label=Star&maxAge=86400)]
-* [wavemap](https://projects.asl.ethz.ch/wavemap/) - Fast, efficient and accurate multi-resolution, multi-sensor 3D occupancy mapping. [[github](https://github.com/ethz-asl/wavemap) ![wavemap](https://img.shields.io/github/stars/ethz-asl/wavemap.svg?style=flat&label=Star&maxAge=86400)]
+* Bonxai - Brutally fast, sparse, 3D Voxel Grid (formerly Treexy). [[github](https://github.com/facontidavide/Bonxai) ⭐ 810]
+* [Goxel](https://guillaumechereau.github.io/goxel/) - Free and open source 3D voxel editor. [[github](https://github.com/guillaumechereau/goxel) ⭐ 3.1k]
+* [libpointmatcher](http://libpointmatcher.readthedocs.io/en/latest/) - Iterative Closest Point library for 2-D/3-D mapping in Robotics. [[github](https://github.com/norlab-ulaval/libpointmatcher) ⭐ 1.8k]
+* [OctoMap](http://octomap.github.io/) - Efficient Probabilistic 3D Mapping Framework Based on Octrees. [[github](https://github.com/OctoMap/octomap) ⭐ 2.3k]
+* Octree - Fast radius neighbor search with an Octree. [[github](https://github.com/jbehley/octree) ⭐ 374]
+* [PCL](https://pointclouds.org/) - 2D/3D image and point cloud processing. [[github](https://github.com/PointCloudLibrary/pcl) ⭐ 10.8k]
 * Utility Software
-* [Goxel](https://guillaumechereau.github.io/goxel/) - Free and open source 3D voxel editor. [[github](https://github.com/guillaumechereau/goxel) ![Goxel](https://img.shields.io/github/stars/guillaumechereau/goxel.svg?style=flat&label=Star&maxAge=86400)]
+* voxblox - Flexible voxel-based mapping focusing on truncated and Euclidean signed distance fields. [[github](https://github.com/ethz-asl/voxblox) ⭐ 1.6k]
+* [wavemap](https://projects.asl.ethz.ch/wavemap/) - Fast, efficient and accurate multi-resolution, multi-sensor 3D occupancy mapping. [[github](https://github.com/ethz-asl/wavemap) ⭐ 551]
 
 ### [Optimization](#contents)
 
 _Numerical optimization solvers and frameworks used in robotics._
 
-* [CasADi](https://github.com/casadi/casadi/wiki) - Symbolic framework for algorithmic differentiation and numeric optimization. [[github](https://github.com/casadi/casadi) ![CasADi](https://img.shields.io/github/stars/casadi/casadi.svg?style=flat&label=Star&maxAge=86400)]
-* [Ceres Solver](http://ceres-solver.org/) - Large scale nonlinear optimization library. [[github](https://github.com/ceres-solver/ceres-solver) ![Ceres Solver](https://img.shields.io/github/stars/ceres-solver/ceres-solver.svg?style=flat&label=Star&maxAge=86400)]
-* eigen-qld - Interface to use the QLD QP solver with the Eigen3 library. [[github](https://github.com/jrl-umi3218/eigen-qld) ![eigen-qld](https://img.shields.io/github/stars/jrl-umi3218/eigen-qld.svg?style=flat&label=Star&maxAge=86400)]
-* EXOTica - Generic optimisation toolset for robotics platforms. [[github](https://github.com/ipab-slmc/exotica) ![EXOTica](https://img.shields.io/github/stars/ipab-slmc/exotica.svg?style=flat&label=Star&maxAge=86400)]
-* hpipm - High-performance interior-point-method QP solvers (Ipopt, Snopt). [[github](https://github.com/giaf/hpipm) ![hpipm](https://img.shields.io/github/stars/giaf/hpipm.svg?style=flat&label=Star&maxAge=86400)]
-* [HYPRE](https://hypre.readthedocs.io/) - Parallel solvers for sparse linear systems featuring multigrid methods. [[github](https://github.com/hypre-space/hypre) ![HYPRE](https://img.shields.io/github/stars/hypre-space/hypre.svg?style=flat&label=Star&maxAge=86400)]
-* ifopt - An Eigen-based, light-weight C++ Interface to Nonlinear Programming Solvers (Ipopt, Snopt). [[github](https://github.com/ethz-adrl/ifopt) ![ifopt](https://img.shields.io/github/stars/ethz-adrl/ifopt.svg?style=flat&label=Star&maxAge=86400)]
-* [Ipopt](https://projects.coin-or.org/Ipopt) - Large scale nonlinear optimization library. [[github](https://github.com/coin-or/Ipopt) ![Ipopt](https://img.shields.io/github/stars/coin-or/Ipopt.svg?style=flat&label=Star&maxAge=86400)]
-* libcmaes - Blackbox stochastic optimization using the CMA-ES algorithm. [[github](https://github.com/CMA-ES/libcmaes) ![libcmaes](https://img.shields.io/github/stars/CMA-ES/libcmaes.svg?style=flat&label=Star&maxAge=86400)]
-* [limbo](http://www.resibots.eu/limbo/) - Gaussian processes and Bayesian optimization of black-box functions. [[github](https://github.com/resibots/limbo) ![limbo](https://img.shields.io/github/stars/resibots/limbo.svg?style=flat&label=Star&maxAge=86400)]
-* lpsolvers - Linear Programming solvers in Python with a unified API. [[github](https://github.com/stephane-caron/lpsolvers) ![lpsolvers](https://img.shields.io/github/stars/stephane-caron/lpsolvers.svg?style=flat&label=Star&maxAge=86400)]
-* [NLopt](https://nlopt.readthedocs.io/en/latest/) - Nonlinear optimization. [[github](https://github.com/stevengj/nlopt) ![NLopt](https://img.shields.io/github/stars/stevengj/nlopt.svg?style=flat&label=Star&maxAge=86400)]
-* [OptimLib](https://www.kthohr.com/optimlib.html) - Lightweight C++ library of numerical optimization methods for nonlinear functions. [[github](https://github.com/kthohr/optim) ![OptimLib](https://img.shields.io/github/stars/kthohr/optim.svg?style=flat&label=Star&maxAge=86400)]
-* [OSQP](https://osqp.org/) - The Operator Splitting QP Solver. [[github](https://github.com/osqp/osqp) ![OSQP](https://img.shields.io/github/stars/osqp/osqp.svg?style=flat&label=Star&maxAge=86400)]
-* [Pagmo](https://esa.github.io/pagmo2/index.html) - Scientific library for massively parallel optimization. [[github](https://github.com/esa/pagmo2) ![Pagmo](https://img.shields.io/github/stars/esa/pagmo2.svg?style=flat&label=Star&maxAge=86400)]
-* [ProxSuite](https://simple-robotics.github.io/proxsuite/) - The Advanced Proximal Optimization Toolbox. [[github](https://github.com/Simple-Robotics/ProxSuite) ![ProxSuite](https://img.shields.io/github/stars/Simple-Robotics/ProxSuite.svg?style=flat&label=Star&maxAge=86400)]
-* [pymoo](https://www.pymoo.org/) - Multi-objective Optimization in Python. [[github](https://github.com/msu-coinlab/pymoo) ![pymoo](https://img.shields.io/github/stars/msu-coinlab/pymoo.svg?style=flat&label=Star&maxAge=86400)]
-* qpsolvers - Quadratic Programming solvers in Python with a unified API. [[github](https://github.com/qpsolvers/qpsolvers) ![qpsolvers](https://img.shields.io/github/stars/qpsolvers/qpsolvers.svg?style=flat&label=Star&maxAge=86400)]
-* [RobOptim](http://roboptim.net/index.html) - Numerical Optimization for Robotics. [[github](https://github.com/roboptim/roboptim-core) ![RobOptim](https://img.shields.io/github/stars/roboptim/roboptim-core.svg?style=flat&label=Star&maxAge=86400)]
-* [SCS](http://web.stanford.edu/~boyd/papers/scs.html) - Numerical optimization for solving large-scale convex cone problems. [[github](https://github.com/cvxgrp/scs) ![SCS](https://img.shields.io/github/stars/cvxgrp/scs.svg?style=flat&label=Star&maxAge=86400)]
-* SHOT - A solver for mixed-integer nonlinear optimization problems. [[github](https://github.com/coin-or/SHOT) ![SHOT](https://img.shields.io/github/stars/coin-or/SHOT.svg?style=flat&label=Star&maxAge=86400)]
-* sferes2 - Evolutionary computation. [[github](https://github.com/sferes2/sferes2) ![sferes2](https://img.shields.io/github/stars/sferes2/sferes2.svg?style=flat&label=Star&maxAge=86400)]
+* [CasADi](https://github.com/casadi/casadi/wiki) - Symbolic framework for algorithmic differentiation and numeric optimization. [[github](https://github.com/casadi/casadi) ⭐ 2.1k]
+* [Ceres Solver](http://ceres-solver.org/) - Large scale nonlinear optimization library. [[github](https://github.com/ceres-solver/ceres-solver) ⭐ 4.4k]
+* eigen-qld - Interface to use the QLD QP solver with the Eigen3 library. [[github](https://github.com/jrl-umi3218/eigen-qld) ⭐ 16]
+* EXOTica - Generic optimisation toolset for robotics platforms. [[github](https://github.com/ipab-slmc/exotica) ⭐ 161]
+* hpipm - High-performance interior-point-method QP solvers (Ipopt, Snopt). [[github](https://github.com/giaf/hpipm) ⭐ 665]
+* [HYPRE](https://hypre.readthedocs.io/) - Parallel solvers for sparse linear systems featuring multigrid methods. [[github](https://github.com/hypre-space/hypre) ⭐ 812]
+* ifopt - An Eigen-based, light-weight C++ Interface to Nonlinear Programming Solvers (Ipopt, Snopt). [[github](https://github.com/ethz-adrl/ifopt) ⭐ 847]
+* [Ipopt](https://projects.coin-or.org/Ipopt) - Large scale nonlinear optimization library. [[github](https://github.com/coin-or/Ipopt) ⭐ 1.7k]
+* libcmaes - Blackbox stochastic optimization using the CMA-ES algorithm. [[github](https://github.com/CMA-ES/libcmaes) ⭐ 354]
+* [limbo](http://www.resibots.eu/limbo/) - Gaussian processes and Bayesian optimization of black-box functions. [[github](https://github.com/resibots/limbo) ⭐ 260]
+* lpsolvers - Linear Programming solvers in Python with a unified API. [[github](https://github.com/stephane-caron/lpsolvers) ⭐ 25]
+* [NLopt](https://nlopt.readthedocs.io/en/latest/) - Nonlinear optimization. [[github](https://github.com/stevengj/nlopt) ⭐ 2.2k]
+* [OptimLib](https://www.kthohr.com/optimlib.html) - Lightweight C++ library of numerical optimization methods for nonlinear functions. [[github](https://github.com/kthohr/optim) ⭐ 885]
+* [OSQP](https://osqp.org/) - The Operator Splitting QP Solver. [[github](https://github.com/osqp/osqp) ⭐ 2.1k]
+* [Pagmo](https://esa.github.io/pagmo2/index.html) - Scientific library for massively parallel optimization. [[github](https://github.com/esa/pagmo2) ⭐ 907]
+* [ProxSuite](https://simple-robotics.github.io/proxsuite/) - The Advanced Proximal Optimization Toolbox. [[github](https://github.com/Simple-Robotics/ProxSuite) ⭐ 538]
+* [pymoo](https://www.pymoo.org/) - Multi-objective Optimization in Python. [[github](https://github.com/msu-coinlab/pymoo) ⭐ 26]
+* qpsolvers - Quadratic Programming solvers in Python with a unified API. [[github](https://github.com/qpsolvers/qpsolvers) ⭐ 725]
+* [RobOptim](http://roboptim.net/index.html) - Numerical Optimization for Robotics. [[github](https://github.com/roboptim/roboptim-core) ⭐ 65]
+* [SCS](http://web.stanford.edu/~boyd/papers/scs.html) - Numerical optimization for solving large-scale convex cone problems. [[github](https://github.com/cvxgrp/scs) ⭐ 613]
+* sferes2 - Evolutionary computation. [[github](https://github.com/sferes2/sferes2) ⭐ 170]
+* SHOT - A solver for mixed-integer nonlinear optimization problems. [[github](https://github.com/coin-or/SHOT) ⭐ 129]
 
 ### [Robot Modeling](#contents)
 
@@ -266,110 +237,110 @@ _Tools and formats for describing robot models._
 ###### Robot Model Description Format
 
 * [SDF](http://sdformat.org/) - XML format that describes objects and environments for robot simulators, visualization, and control. [[bitbucket](https://bitbucket.org/osrf/sdformat)]
-* [urdf](http://wiki.ros.org/urdf) - XML format for representing a robot model. [[github](https://github.com/ros/urdfdom) ![urdf](https://img.shields.io/github/stars/ros/urdfdom.svg?style=flat&label=Star&maxAge=86400)]
+* [urdf](http://wiki.ros.org/urdf) - XML format for representing a robot model. [[github](https://github.com/ros/urdfdom) ⭐ 118]
 
 ###### Utility to Build Robot Models
 
-* [onshape-to-robot](https://github.com/Rhoban/onshape-to-robot) - Converting OnShape assembly to robot definition (SDF or URDF) through OnShape API. [[github](https://github.com/Rhoban/onshape-to-robot) ![onshape-to-robot](https://img.shields.io/github/stars/Rhoban/onshape-to-robot.svg?style=flat&label=Star&maxAge=86400)]
-* phobos - Add-on for Blender creating URDF and SMURF robot models. [[github](https://github.com/dfki-ric/phobos) ![phobos](https://img.shields.io/github/stars/dfki-ric/phobos.svg?style=flat&label=Star&maxAge=86400)]
+* [onshape-to-robot](https://github.com/Rhoban/onshape-to-robot) - Converting OnShape assembly to robot definition (SDF or URDF) through OnShape API. [[github](https://github.com/Rhoban/onshape-to-robot) ⭐ 486]
+* phobos - Add-on for Blender creating URDF and SMURF robot models. [[github](https://github.com/dfki-ric/phobos) ⭐ 855]
 
 ### [Robot Platform](#contents)
 
 _Middleware and frameworks for building robot software systems._
 
-* [AutoRally](http://autorally.github.io/) - High-performance testbed for advanced perception and control research. [[github](https://github.com/autorally/autorally) ![AutoRally](https://img.shields.io/github/stars/autorally/autorally.svg?style=flat&label=Star&maxAge=86400)]
-* [Linorobot](https://linorobot.org/) - ROS compatible ground robots. [[github](https://github.com/linorobot/linorobot) ![Linorobot](https://img.shields.io/github/stars/linorobot/linorobot.svg?style=flat&label=Star&maxAge=86400)]
-  * onine - Service Robot based on Linorobot and Braccio Arm. [[github](https://github.com/grassjelly/onine) ![onine](https://img.shields.io/github/stars/grassjelly/onine.svg?style=flat&label=Star&maxAge=86400)]
-* [Micro-ROS for Arduino](https://github.com/kaiaai/micro_ros_arduino_kaiaai) - a Micro-ROS fork available in the Arduino Library Manager. [[github](https://github.com/kaiaai/micro_ros_arduino_kaiaai) ![Micro-ROS for Arduino](https://img.shields.io/github/stars/kaiaai/micro_ros_arduino_kaiaai.svg?style=flat&label=Star&maxAge=86400)]
+* [AutoRally](http://autorally.github.io/) - High-performance testbed for advanced perception and control research. [[github](https://github.com/autorally/autorally) ⭐ 775]
+* [Linorobot](https://linorobot.org/) - ROS compatible ground robots. [[github](https://github.com/linorobot/linorobot) ⭐ 1.1k]
+  * onine - Service Robot based on Linorobot and Braccio Arm. [[github](https://github.com/grassjelly/onine) ⭐ 47]
+* [Micro-ROS for Arduino](https://github.com/kaiaai/micro_ros_arduino_kaiaai) - a Micro-ROS fork available in the Arduino Library Manager. [[github](https://github.com/kaiaai/micro_ros_arduino_kaiaai) ⭐ 12]
 * [Rock](https://www.rock-robotics.org/) - Software framework for robotic systems.
 * [ROS](https://www.ros.org/) - Flexible framework for writing robot software.
-* [ROS 2](https://github.com/ros2/ros2/wiki) - Version 2.0 of the Robot Operating System (ROS) software stack. [[github](https://github.com/ros2/ros2) ![ROS 2](https://img.shields.io/github/stars/ros2/ros2.svg?style=flat&label=Star&maxAge=86400)]
-* [YARP](https://www.yarp.it/) - Communication and device interfaces applicable from humanoids to embedded devices. [[github](https://github.com/robotology/yarp) ![YARP](https://img.shields.io/github/stars/robotology/yarp.svg?style=flat&label=Star&maxAge=86400)]
+* [ROS 2](https://github.com/ros2/ros2/wiki) - Version 2.0 of the Robot Operating System (ROS) software stack. [[github](https://github.com/ros2/ros2) ⭐ 5k]
+* [YARP](https://www.yarp.it/) - Communication and device interfaces applicable from humanoids to embedded devices. [[github](https://github.com/robotology/yarp) ⭐ 585]
 
 ### [Reinforcement Learning for Robotics](#contents)
 
 _Reinforcement learning libraries commonly used in robotic control._
 
-* [CleanRL](https://github.com/vwxyzjn/cleanrl) - Single-file implementations of deep reinforcement learning algorithms. [[github](https://github.com/vwxyzjn/cleanrl) ![CleanRL](https://img.shields.io/github/stars/vwxyzjn/cleanrl.svg?style=flat&label=Star&maxAge=86400)]
-* [rl_games](https://github.com/Denys88/rl_games) - High-performance RL library used in Isaac Gym environments. [[github](https://github.com/Denys88/rl_games) ![rl_games](https://img.shields.io/github/stars/Denys88/rl_games.svg?style=flat&label=Star&maxAge=86400)]
-* [SKRL](https://github.com/Toni-SM/skrl) - Modular reinforcement learning library with support for multiple ML frameworks. [[github](https://github.com/Toni-SM/skrl) ![SKRL](https://img.shields.io/github/stars/Toni-SM/skrl.svg?style=flat&label=Star&maxAge=86400)]
-* [Stable-Baselines3](https://github.com/DLR-RM/stable-baselines3) - Reliable implementations of reinforcement learning algorithms in PyTorch. [[github](https://github.com/DLR-RM/stable-baselines3) ![Stable-Baselines3](https://img.shields.io/github/stars/DLR-RM/stable-baselines3.svg?style=flat&label=Star&maxAge=86400)]
+* [CleanRL](https://github.com/vwxyzjn/cleanrl) - Single-file implementations of deep reinforcement learning algorithms. [[github](https://github.com/vwxyzjn/cleanrl) ⭐ 9k]
+* [rl_games](https://github.com/Denys88/rl_games) - High-performance RL library used in Isaac Gym environments. [[github](https://github.com/Denys88/rl_games) ⭐ 1.3k]
+* [SKRL](https://github.com/Toni-SM/skrl) - Modular reinforcement learning library with support for multiple ML frameworks. [[github](https://github.com/Toni-SM/skrl) ⭐ 982]
+* [Stable-Baselines3](https://github.com/DLR-RM/stable-baselines3) - Reliable implementations of reinforcement learning algorithms in PyTorch. [[github](https://github.com/DLR-RM/stable-baselines3) ⭐ 12.7k]
 
 ### [SLAM](#contents)
 
 _Simultaneous Localization and Mapping libraries._
 
 
-* AprilSAM - Real-time smoothing and mapping. [[github](https://github.com/xipengwang/AprilSAM) ![AprilSAM](https://img.shields.io/github/stars/xipengwang/AprilSAM.svg?style=flat&label=Star&maxAge=86400)]
-* Cartographer - Real-time SLAM in 2D and 3D across multiple platforms and sensor configurations. [[github](https://github.com/cartographer-project/cartographer) ![Cartographer](https://img.shields.io/github/stars/cartographer-project/cartographer.svg?style=flat&label=Star&maxAge=86400)]
-* [DSO](https://vision.in.tum.de/research/vslam/dso) - Novel direct and sparse formulation for Visual Odometry. [[github](https://github.com/JakobEngel/dso) ![DSO](https://img.shields.io/github/stars/JakobEngel/dso.svg?style=flat&label=Star&maxAge=86400)]
-* ElasticFusion - Real-time dense visual SLAM system. [[github](https://github.com/mp3guy/ElasticFusion) ![ElasticFusion](https://img.shields.io/github/stars/mp3guy/ElasticFusion.svg?style=flat&label=Star&maxAge=86400)]
-* [fiducials](http://wiki.ros.org/fiducials) - Simultaneous localization and mapping using fiducial markers. [[github](https://github.com/UbiquityRobotics/fiducials) ![fiducials](https://img.shields.io/github/stars/UbiquityRobotics/fiducials.svg?style=flat&label=Star&maxAge=86400)]
-* GTSAM - Smoothing and mapping (SAM) in robotics and vision. [[github](https://github.com/borglab/gtsam) ![GTSAM](https://img.shields.io/github/stars/borglab/gtsam.svg?style=flat&label=Star&maxAge=86400)]
-* Kintinuous - Real-time large scale dense visual SLAM system. [[github](https://github.com/mp3guy/Kintinuous) ![Kintinuous](https://img.shields.io/github/stars/mp3guy/Kintinuous.svg?style=flat&label=Star&maxAge=86400)]
-* [LSD-SLAM](https://vision.in.tum.de/research/vslam/lsdslam) - Real-time monocular SLAM. [[github](https://github.com/tum-vision/lsd_slam) ![LSD-SLAM](https://img.shields.io/github/stars/tum-vision/lsd_slam.svg?style=flat&label=Star&maxAge=86400)]
-* ORB-SLAM2 - Real-time SLAM library for Monocular, Stereo and RGB-D cameras. [[github](https://github.com/raulmur/ORB_SLAM2) ![ORB-SLAM2](https://img.shields.io/github/stars/raulmur/ORB_SLAM2.svg?style=flat&label=Star&maxAge=86400)]
-* [RTAP-Map](http://introlab.github.io/rtabmap/) - RGB-D Graph SLAM approach based on a global Bayesian loop closure detector. [[github](https://github.com/introlab/rtabmap) ![RTAP-Map](https://img.shields.io/github/stars/introlab/rtabmap.svg?style=flat&label=Star&maxAge=86400)]
-* [SRBA](http://mrpt.github.io/srba/) - Solving SLAM/BA in relative coordinates with flexibility for different submapping strategies. [[github](https://github.com/MRPT/srba) ![SRBA](https://img.shields.io/github/stars/MRPT/srba.svg?style=flat&label=Star&maxAge=86400)]
+* AprilSAM - Real-time smoothing and mapping. [[github](https://github.com/xipengwang/AprilSAM) ⭐ 239]
+* Cartographer - Real-time SLAM in 2D and 3D across multiple platforms and sensor configurations. [[github](https://github.com/cartographer-project/cartographer) ⭐ 7.8k]
+* [DSO](https://vision.in.tum.de/research/vslam/dso) - Novel direct and sparse formulation for Visual Odometry. [[github](https://github.com/JakobEngel/dso) ⭐ 2.4k]
+* ElasticFusion - Real-time dense visual SLAM system. [[github](https://github.com/mp3guy/ElasticFusion) ⭐ 1.9k]
+* [fiducials](http://wiki.ros.org/fiducials) - Simultaneous localization and mapping using fiducial markers. [[github](https://github.com/UbiquityRobotics/fiducials) ⭐ 278]
+* GTSAM - Smoothing and mapping (SAM) in robotics and vision. [[github](https://github.com/borglab/gtsam) ⭐ 3.3k]
+* Kintinuous - Real-time large scale dense visual SLAM system. [[github](https://github.com/mp3guy/Kintinuous) ⭐ 951]
+* [LSD-SLAM](https://vision.in.tum.de/research/vslam/lsdslam) - Real-time monocular SLAM. [[github](https://github.com/tum-vision/lsd_slam) ⭐ 2.7k]
+* ORB-SLAM2 - Real-time SLAM library for Monocular, Stereo and RGB-D cameras. [[github](https://github.com/raulmur/ORB_SLAM2) ⭐ 10.1k]
+* [RTAP-Map](http://introlab.github.io/rtabmap/) - RGB-D Graph SLAM approach based on a global Bayesian loop closure detector. [[github](https://github.com/introlab/rtabmap) ⭐ 3.6k]
+* [SRBA](http://mrpt.github.io/srba/) - Solving SLAM/BA in relative coordinates with flexibility for different submapping strategies. [[github](https://github.com/MRPT/srba) ⭐ 76]
 
 #### SLAM Dataset
 
-* [Awesome SLAM Datasets](https://github.com/youngguncho/awesome-slam-datasets) - Curated list of SLAM-related datasets. [[github](https://github.com/youngguncho/awesome-slam-datasets) ![Awesome SLAM Datasets](https://img.shields.io/github/stars/youngguncho/awesome-slam-datasets.svg?style=flat&label=Star&maxAge=86400)]
+* [Awesome SLAM Datasets](https://github.com/youngguncho/awesome-slam-datasets) - Curated list of SLAM-related datasets. [[github](https://github.com/youngguncho/awesome-slam-datasets) ⭐ 1.9k]
 
 ### [Vision](#contents)
 
 _Computer vision libraries for robotic perception._
 
-* [ViSP](http://visp.inria.fr/) - Visual Servoing Platform. [[github](https://github.com/lagadic/visp) ![ViSP](https://img.shields.io/github/stars/lagadic/visp.svg?style=flat&label=Star&maxAge=86400)]
-* [BundleTrack](https://github.com/wenbowen123/BundleTrack) - 6D Pose Tracking for Novel Objects without 3D Models. [[github](https://github.com/wenbowen123/BundleTrack) ![BundleTrack](https://img.shields.io/github/stars/wenbowen123/BundleTrack.svg?style=flat&label=Star&maxAge=86400)]
-* [se(3)-TrackNet](https://github.com/wenbowen123/iros20-6d-pose-tracking) - 6D Pose Tracking for Novel Objects without 3D Models. [[github](https://github.com/wenbowen123/iros20-6d-pose-tracking) ![se(3)-TrackNet](https://img.shields.io/github/stars/wenbowen123/iros20-6d-pose-tracking.svg?style=flat&label=Star&maxAge=86400)]
+* [BundleTrack](https://github.com/wenbowen123/BundleTrack) - 6D Pose Tracking for Novel Objects without 3D Models. [[github](https://github.com/wenbowen123/BundleTrack) ⭐ 678]
+* [se(3)-TrackNet](https://github.com/wenbowen123/iros20-6d-pose-tracking) - 6D Pose Tracking for Novel Objects without 3D Models. [[github](https://github.com/wenbowen123/iros20-6d-pose-tracking) ⭐ 420]
+* [ViSP](http://visp.inria.fr/) - Visual Servoing Platform. [[github](https://github.com/lagadic/visp) ⭐ 849]
 
 ### [Fluid](#contents)
 
 _Fluid dynamics simulation libraries._
 
-* [Fluid Engine Dev - Jet](https://fluidenginedevelopment.org/) - Fluid simulation engine for computer graphics applications. [[github](https://github.com/doyubkim/fluid-engine-dev) ![Fluid Engine Dev - Jet](https://img.shields.io/github/stars/doyubkim/fluid-engine-dev.svg?style=flat&label=Star&maxAge=86400)]
+* [Fluid Engine Dev - Jet](https://fluidenginedevelopment.org/) - Fluid simulation engine for computer graphics applications. [[github](https://github.com/doyubkim/fluid-engine-dev) ⭐ 2.1k]
 
 ### [Grasping](#contents)
 
 _Libraries and tools for robotic grasping and manipulation._
 
-* [AnyGrasp SDK](https://github.com/graspnet/anygrasp_sdk) - SDK for AnyGrasp, a 6-DoF grasp pose detection method. [[github](https://github.com/graspnet/anygrasp_sdk) ![AnyGrasp SDK](https://img.shields.io/github/stars/graspnet/anygrasp_sdk.svg?style=flat&label=Star&maxAge=86400)]
-* [Contact-GraspNet](https://github.com/NVlabs/contact_graspnet) - 6-DoF grasp generation for parallel-jaw grippers using contact maps. [[github](https://github.com/NVlabs/contact_graspnet) ![Contact-GraspNet](https://img.shields.io/github/stars/NVlabs/contact_graspnet.svg?style=flat&label=Star&maxAge=86400)]
-* [GraspNet API](https://github.com/graspnet/graspnetAPI) - Python API and evaluation tools for the GraspNet benchmark. [[github](https://github.com/graspnet/graspnetAPI) ![GraspNet API](https://img.shields.io/github/stars/graspnet/graspnetAPI.svg?style=flat&label=Star&maxAge=86400)]
-* [GraspIt!](https://graspit-simulator.github.io/) - Simulator for grasping research that can accommodate arbitrary hand and robot designs. [[github](https://github.com/graspit-simulator/graspit) ![GraspIt!](https://img.shields.io/github/stars/graspit-simulator/graspit.svg?style=flat&label=Star&maxAge=86400)]
+* [AnyGrasp SDK](https://github.com/graspnet/anygrasp_sdk) - SDK for AnyGrasp, a 6-DoF grasp pose detection method. [[github](https://github.com/graspnet/anygrasp_sdk) ⭐ 752]
+* [Contact-GraspNet](https://github.com/NVlabs/contact_graspnet) - 6-DoF grasp generation for parallel-jaw grippers using contact maps. [[github](https://github.com/NVlabs/contact_graspnet) ⭐ 449]
+* [GraspIt!](https://graspit-simulator.github.io/) - Simulator for grasping research that can accommodate arbitrary hand and robot designs. [[github](https://github.com/graspit-simulator/graspit) ⭐ 207]
+* [GraspNet API](https://github.com/graspnet/graspnetAPI) - Python API and evaluation tools for the GraspNet benchmark. [[github](https://github.com/graspnet/graspnetAPI) ⭐ 323]
 
 ### [Humanoid Robotics](#contents)
 
 _Environments and models for humanoid robot research._
 
-* [Humanoid-Gym](https://github.com/roboterax/humanoid-gym) - Reinforcement learning environment for humanoid robot locomotion. [[github](https://github.com/roboterax/humanoid-gym) ![Humanoid-Gym](https://img.shields.io/github/stars/roboterax/humanoid-gym.svg?style=flat&label=Star&maxAge=86400)]
-* [Legged Gym](https://github.com/leggedrobotics/legged_gym) - Isaac Gym environments for legged robot locomotion training. [[github](https://github.com/leggedrobotics/legged_gym) ![Legged Gym](https://img.shields.io/github/stars/leggedrobotics/legged_gym.svg?style=flat&label=Star&maxAge=86400)]
-* [MuJoCo Menagerie](https://github.com/google-deepmind/mujoco_menagerie) - Collection of well-tuned MuJoCo models for research and development. [[github](https://github.com/google-deepmind/mujoco_menagerie) ![MuJoCo Menagerie](https://img.shields.io/github/stars/google-deepmind/mujoco_menagerie.svg?style=flat&label=Star&maxAge=86400)]
+* [Humanoid-Gym](https://github.com/roboterax/humanoid-gym) - Reinforcement learning environment for humanoid robot locomotion. [[github](https://github.com/roboterax/humanoid-gym) ⭐ 1.8k]
+* [Legged Gym](https://github.com/leggedrobotics/legged_gym) - Isaac Gym environments for legged robot locomotion training. [[github](https://github.com/leggedrobotics/legged_gym) ⭐ 2.7k]
+* [MuJoCo Menagerie](https://github.com/google-deepmind/mujoco_menagerie) - Collection of well-tuned MuJoCo models for research and development. [[github](https://github.com/google-deepmind/mujoco_menagerie) ⭐ 3k]
 
 ### [Multiphysics](#contents)
 
 _Frameworks for coupled multi-physics simulations._
 
-* [Kratos](http://www.cimne.com/kratos/) - Framework for building parallel multi-disciplinary simulation software. [[github](https://github.com/KratosMultiphysics/Kratos) ![Kratos](https://img.shields.io/github/stars/KratosMultiphysics/Kratos.svg?style=flat&label=Star&maxAge=86400)]
+* [Kratos](http://www.cimne.com/kratos/) - Framework for building parallel multi-disciplinary simulation software. [[github](https://github.com/KratosMultiphysics/Kratos) ⭐ 1.2k]
 
 ### [Math](#contents)
 
 _Mathematics libraries for spatial algebra, Lie groups, and linear algebra._
 
-* Fastor - Light-weight high performance tensor algebra framework in C++11/14/17. [[github](https://github.com/romeric/Fastor) ![Fastor](https://img.shields.io/github/stars/romeric/Fastor.svg?style=flat&label=Star&maxAge=86400)]
-* linalg.h - Single header public domain linear algebra library for C++11. [[github](https://github.com/sgorsten/linalg) ![linalg.h](https://img.shields.io/github/stars/sgorsten/linalg.svg?style=flat&label=Star&maxAge=86400)]
-* manif - Small c++11 header-only library for Lie theory. [[github](https://github.com/artivis/manif) ![manif](https://img.shields.io/github/stars/artivis/manif.svg?style=flat&label=Star&maxAge=86400)]
-* Sophus - Lie groups using Eigen. [[github](https://github.com/strasdat/Sophus) ![Sophus](https://img.shields.io/github/stars/strasdat/Sophus.svg?style=flat&label=Star&maxAge=86400)]
-* SpaceVelAlg - Spatial vector algebra with the Eigen3. [[github](https://github.com/jrl-umi3218/SpaceVecAlg) ![SpaceVelAlg](https://img.shields.io/github/stars/jrl-umi3218/SpaceVecAlg.svg?style=flat&label=Star&maxAge=86400)]
-* spatialmath-python - A python package provides classes to represent pose and orientation in 3D and 2D space, along with a toolbox of spatial operations. [[github](https://github.com/bdaiinstitute/spatialmath-python) ![spatialmath-python](https://img.shields.io/github/stars/bdaiinstitute/spatialmath-python.svg?style=flat&label=Star&maxAge=86400)]
+* Fastor - Light-weight high performance tensor algebra framework in C++11/14/17. [[github](https://github.com/romeric/Fastor) ⭐ 830]
+* linalg.h - Single header public domain linear algebra library for C++11. [[github](https://github.com/sgorsten/linalg) ⭐ 939]
+* manif - Small c++11 header-only library for Lie theory. [[github](https://github.com/artivis/manif) ⭐ 1.7k]
+* Sophus - Lie groups using Eigen. [[github](https://github.com/strasdat/Sophus) ⭐ 2.4k]
+* SpaceVelAlg - Spatial vector algebra with the Eigen3. [[github](https://github.com/jrl-umi3218/SpaceVecAlg) ⭐ 80]
+* spatialmath-python - A python package provides classes to represent pose and orientation in 3D and 2D space, along with a toolbox of spatial operations. [[github](https://github.com/bdaiinstitute/spatialmath-python) ⭐ 615]
 
 ### [ETC](#contents)
 
 _Other robotics-related tools and utilities._
 
-* fuse - General architecture for performing sensor fusion live on a robot. [[github](https://github.com/locusrobotics/fuse) ![fuse](https://img.shields.io/github/stars/locusrobotics/fuse.svg?style=flat&label=Star&maxAge=86400)]
 * [Foxglove Studio](https://foxglove.dev) - A fully integrated visualization and debugging desktop app for your robotics data.
+* fuse - General architecture for performing sensor fusion live on a robot. [[github](https://github.com/locusrobotics/fuse) ⭐ 847]
 
 ## [Other Awesome Lists](#contents)
 

--- a/data/dynamics-simulation.yaml
+++ b/data/dynamics-simulation.yaml
@@ -1,345 +1,671 @@
-# dynamics-simulation
-# Source of truth — edit this file, then run: pixi run generate
-
 - name: ARCSim
-  url: "http://graphics.berkeley.edu/resources/ARCSim/index.html"
-  languages: [C++]
-  models: [soft]
-
+  url: http://graphics.berkeley.edu/resources/ARCSim/index.html
+  description: Adaptive remeshing cloth and shell simulator for thin deformable objects.
+  languages:
+  - C++
+  models:
+  - soft
 
 - name: Bullet
-  url: "https://pybullet.org/"
+  url: https://pybullet.org/
+  description: Real-time physics simulation for games, visual effects, and robotics.
   github: bulletphysics/bullet3
   license: Zlib
-  languages: [C++, Python]
-  models: [rigid, soft]
-  features: [ik, id, urdf, sdf]
+  languages:
+  - C++
+  - Python
+  models:
+  - rigid
+  - soft
+  features:
+  - ik
+  - id
+  - urdf
+  - sdf
+  _meta:
+    stars: 14206
+    last_commit: '2025-10-22'
+    language: C++
 
-
-- name: "CHRONO::ENGINE"
-  url: "https://projectchrono.org/"
+- name: CHRONO::ENGINE
+  url: https://projectchrono.org/
+  description: Multi-physics simulation of rigid and flexible bodies, granular, and fluid systems.
   github: projectchrono/chrono
   license: BSD-3-Clause
-  languages: [C++, Python]
-  models: [rigid, soft, granular, fluid]
-  features: [ik, urdf]
-
+  languages:
+  - C++
+  - Python
+  models:
+  - rigid
+  - soft
+  - granular
+  - fluid
+  features:
+  - ik
+  - urdf
+  _meta:
+    stars: 2706
+    last_commit: '2026-01-31'
+    license: BSD-3-Clause
+    language: C++
 
 - name: DART
-  url: "http://dartsim.github.io/"
+  url: http://dartsim.github.io/
+  description: Dynamic Animation and Robotics Toolkit for multibody simulation and planning.
   github: dartsim/dart
   license: BSD-2-Clause
-  languages: [C++, Python]
-  models: [rigid, soft]
-  features: [ik, id, plan, urdf, sdf]
-
+  languages:
+  - C++
+  - Python
+  models:
+  - rigid
+  - soft
+  features:
+  - ik
+  - id
+  - plan
+  - urdf
+  - sdf
+  _meta:
+    stars: 1052
+    last_commit: '2026-02-02'
+    license: BSD-2-Clause
+    language: C++
 
 - name: Drake
-  url: "https://drake.mit.edu/"
+  url: https://drake.mit.edu/
+  description: Planning, control, and analysis toolbox for nonlinear dynamical systems.
   github: RobotLocomotion/drake
   license: BSD-3-Clause
-  languages: [C++, Matlab]
-  models: [rigid, aero, fluid]
-  features: [ik, trj-opt, plan]
-
+  languages:
+  - C++
+  - Matlab
+  models:
+  - rigid
+  - aero
+  - fluid
+  features:
+  - ik
+  - trj-opt
+  - plan
+  _meta:
+    stars: 3890
+    last_commit: '2026-02-02'
+    language: C++
 
 - name: Flex
-  url: "https://developer.nvidia.com/flex"
+  url: https://developer.nvidia.com/flex
+  description: GPU-based particle simulation for rigid bodies, fluids, and deformables.
   github: NVIDIAGameWorks/FleX
-  languages: [C++]
-  models: [rigid, soft, particle, fluid]
-
+  languages:
+  - C++
+  models:
+  - rigid
+  - soft
+  - particle
+  - fluid
+  _meta:
+    stars: 787
+    last_commit: '2021-04-15'
+    language: C++
 
 - name: FROST
-  url: "https://ayonga.github.io/frost-dev/index.html"
+  url: https://ayonga.github.io/frost-dev/index.html
+  description: Fast Robot Optimization and Simulation Toolkit for hybrid dynamical systems in MATLAB.
   github: ayonga/frost-dev
   license: BSD-3-Clause
-  languages: [MATLAB]
-  models: [rigid]
-
+  languages:
+  - MATLAB
+  models:
+  - rigid
+  _meta:
+    stars: 169
+    last_commit: '2023-11-29'
+    language: MATLAB
 
 - name: IBDS
-  url: "http://www.interactive-graphics.de/index.php/downloads/12-ibds"
+  url: http://www.interactive-graphics.de/index.php/downloads/12-ibds
+  description: Impulse-based dynamics simulation for rigid bodies and particle systems.
   license: Zlib
-  languages: [C++]
-  models: [rigid, particle]
-
+  languages:
+  - C++
+  models:
+  - rigid
+  - particle
 
 - name: idyntree
+  description: Library for estimation and whole-body dynamics of floating-base robots.
   github: gbionics/idyntree
   license: LGPL-2.1
-  languages: [C++, Python, Matlab, Lua]
-  models: [rigid]
-  features: [id]
-
+  languages:
+  - C++
+  - Python
+  - Matlab
+  - Lua
+  models:
+  - rigid
+  features:
+  - id
+  _meta:
+    stars: 223
+    last_commit: '2026-01-30'
+    license: BSD-3-Clause
+    language: C++
 
 - name: KDL
-  url: "https://www.orocos.org/kdl.html"
+  url: https://www.orocos.org/kdl.html
+  description: Orocos Kinematics and Dynamics Library for kinematic chains.
   github: orocos/orocos_kinematics_dynamics
   license: LGPL-2.1
-  languages: [C++]
-  models: [rigid]
-  features: [ik]
-
+  languages:
+  - C++
+  models:
+  - rigid
+  features:
+  - ik
+  _meta:
+    stars: 857
+    last_commit: '2025-12-23'
+    language: C++
 
 - name: kindr
+  description: Kinematics and dynamics library for rigid body transformations.
   github: ANYbotics/kindr
   license: BSD-3-Clause
-  languages: [C++, Matlab]
-  models: [rigid]
-
+  languages:
+  - C++
+  - Matlab
+  models:
+  - rigid
+  _meta:
+    stars: 607
+    last_commit: '2025-02-15'
+    license: BSD-3-Clause
+    language: C++
 
 - name: Klampt
-  url: "https://klampt.org/"
+  url: https://klampt.org/
+  description: Robot planning, control, and simulation with visualization support.
   github: krishauser/Klampt
   license: BSD-3-Clause
-  languages: [C++, Python]
-
+  languages:
+  - C++
+  - Python
+  _meta:
+    stars: 427
+    last_commit: '2026-01-10'
+    license: BSD-3-Clause
+    language: C++
 
 - name: LibrePilot
-  url: "http://www.librepilot.org/site/index.html"
+  url: http://www.librepilot.org/site/index.html
+  description: Open-source autopilot for UAVs and other autonomous vehicles.
   bitbucket: librepilot/librepilot
   github: librepilot/LibrePilot
   license: GPL-3.0
-  languages: [C++]
-  models: [uav, vehicles]
-
+  languages:
+  - C++
+  models:
+  - uav
+  - vehicles
+  _meta:
+    stars: 348
+    last_commit: '2023-12-14'
+    language: C
 
 - name: MARS
-  url: "http://rock-simulation.github.io/mars/"
+  url: http://rock-simulation.github.io/mars/
+  description: Machina Arte Robotum Simulans — a cross-platform simulation environment.
   github: rock-simulation/mars
   license: LGPL-3.0
-  languages: [C++, Python]
-
+  languages:
+  - C++
+  - Python
+  _meta:
+    stars: 67
+    last_commit: '2025-09-01'
+    language: C++
 
 - name: MBDyn
-  url: "https://www.mbdyn.org/"
-  code_url: "https://www.mbdyn.org/?Software_Download"
+  url: https://www.mbdyn.org/
+  description: General-purpose multibody dynamics analysis software.
+  code_url: https://www.mbdyn.org/?Software_Download
   license: GPL-2.1
-  languages: [C++]
-
+  languages:
+  - C++
 
 - name: MBSim
-  url: "https://www.mbsim-env.de/"
+  url: https://www.mbsim-env.de/
+  description: Multi-body simulation environment for flexible and rigid systems.
   github: mbsim-env/mbsim
   license: (not specified)
-  languages: [C++]
-
+  languages:
+  - C++
+  _meta:
+    stars: 51
+    last_commit: '2026-02-02'
+    license: LGPL-2.1
+    language: C++
 
 - name: MBSlib
-  url: "http://www.sim.informatik.tu-darmstadt.de/res/sw/mbslib"
+  url: http://www.sim.informatik.tu-darmstadt.de/res/sw/mbslib
+  description: Lightweight multibody system dynamics library.
   github: SIM-TU-Darmstadt/mbslib
   license: LGPL-3.0
-  languages: [C++]
-
+  languages:
+  - C++
+  _meta:
+    stars: 11
+    last_commit: '2016-08-17'
+    license: LGPL-3.0
+    language: C++
 
 - name: metapod
+  description: Template-based robot dynamics library using spatial algebra.
   github: laas/metapod
   license: LGPL-3.0
-  languages: [C++]
-
+  languages:
+  - C++
+  _meta:
+    stars: 14
+    last_commit: '2018-09-10'
+    archived: true
+    license: LGPL-3.0
+    language: C++
 
 - name: Moby
-  url: "http://physsim.sourceforge.net/index.html"
+  url: http://physsim.sourceforge.net/index.html
+  description: Multi-body dynamics simulation for rigid bodies with contact.
   github: PositronicsLab/Moby
   license: GPL-2.0
-  languages: [C++]
-  models: [rigid]
-  features: [id]
-
+  languages:
+  - C++
+  models:
+  - rigid
+  features:
+  - id
+  _meta:
+    stars: 37
+    last_commit: '2021-11-26'
+    language: C++
 
 - name: mrpt
-  url: "https://www.mrpt.org/"
+  url: https://www.mrpt.org/
+  description: Mobile Robot Programming Toolkit for SLAM, navigation, and computer vision.
   github: MRPT/mrpt
   license: BSD-3-Clause
-  languages: [C++, Python, Matlab]
-  models: [vehicle]
-  features: [slam, cv]
-
+  languages:
+  - C++
+  - Python
+  - Matlab
+  models:
+  - vehicle
+  features:
+  - slam
+  - cv
+  _meta:
+    stars: 2110
+    last_commit: '2026-02-02'
+    license: BSD-3-Clause
+    language: C++
 
 - name: MuJoCo
-  url: "https://mujoco.org/"
+  url: https://mujoco.org/
+  description: Multi-joint dynamics with contact for physics-based simulation and control.
   github: google-deepmind/mujoco
   license: Apache-2.0
-  languages: [C++, Python]
-  features: [id]
-
+  languages:
+  - C++
+  - Python
+  features:
+  - id
+  _meta:
+    stars: 11899
+    last_commit: '2026-02-02'
+    license: Apache-2.0
+    language: C++
 
 - name: mvsim
-  url: "http://wiki.ros.org/mvsim"
+  url: http://wiki.ros.org/mvsim
+  description: Lightweight multi-vehicle 2D simulator with ROS integration.
   github: MRPT/mvsim
   license: GPL-3.0
-  languages: [C++]
-  models: [vehicle]
-
+  languages:
+  - C++
+  models:
+  - vehicle
+  _meta:
+    stars: 359
+    last_commit: '2026-01-29'
+    license: BSD-3-Clause
+    language: C++
 
 - name: Newton Dynamics
-  url: "https://newtondynamics.com/"
+  url: https://newtondynamics.com/
+  description: Real-time physics engine for rigid body simulation.
   github: MADEAPPS/newton-dynamics
   license: Zlib
-  languages: [C++]
-
+  languages:
+  - C++
+  _meta:
+    stars: 1022
+    last_commit: '2026-01-17'
+    language: HTML
 
 - name: nphysics
-  url: "https://nphysics.org/"
+  url: https://nphysics.org/
+  description: 2D and 3D rigid body physics engine written in Rust.
   github: dimforge/nphysics
   license: BSD-3-Clause
-  languages: [Rust]
-
+  languages:
+  - Rust
+  _meta:
+    stars: 1646
+    last_commit: '2021-07-27'
+    license: Apache-2.0
+    language: Rust
 
 - name: ODE
-  url: "https://ode.org/"
+  url: https://ode.org/
+  description: Open Dynamics Engine for simulating rigid body dynamics.
   bitbucket: odedevs/ode
   license: LGPL-2.1 or BSD-3-Clause
-  languages: [C++]
-  models: [rigid]
-
+  languages:
+  - C++
+  models:
+  - rigid
 
 - name: OpenRAVE
-  url: "https://www.openrave.org/"
+  url: https://www.openrave.org/
+  description: Open Robotics Automation Virtual Environment for planning and simulation.
   github: rdiankov/openrave
   license: LGPL-3.0
-  languages: [C++, Python]
-
+  languages:
+  - C++
+  - Python
+  _meta:
+    stars: 798
+    last_commit: '2026-02-02'
+    language: C++
 
 - name: pinocchio
-  url: "https://stack-of-tasks.github.io/pinocchio/"
+  url: https://stack-of-tasks.github.io/pinocchio/
+  description: Fast and flexible algorithms for rigid-body dynamics with analytical derivatives.
   github: stack-of-tasks/pinocchio
   license: BSD-2-Clause
-  languages: [C++, Python]
-  models: [rigid]
-  features: [ik, id, urdf, analytical derivatives, code generation]
-
+  languages:
+  - C++
+  - Python
+  models:
+  - rigid
+  features:
+  - ik
+  - id
+  - urdf
+  - analytical derivatives
+  - code generation
+  _meta:
+    stars: 3089
+    last_commit: '2026-02-02'
+    license: BSD-2-Clause
+    language: C++
 
 - name: PositionBasedDynamics
+  description: Position-based methods for simulating deformable objects and fluids.
   github: InteractiveComputerGraphics/PositionBasedDynamics
   license: MIT
-  languages: [C++]
-
+  languages:
+  - C++
+  _meta:
+    stars: 2175
+    last_commit: '2025-09-04'
+    license: MIT
+    language: C++
 
 - name: PhysX
-  url: "https://nvidia-omniverse.github.io/PhysX/physx/5.5.0/index.html"
+  url: https://nvidia-omniverse.github.io/PhysX/physx/5.5.0/index.html
+  description: NVIDIA physics engine for real-time rigid body and vehicle simulation.
   github: NVIDIA-Omniverse/PhysX
   license: unknown
-  languages: [C++]
-
+  languages:
+  - C++
+  _meta:
+    stars: 4377
+    last_commit: '2025-10-21'
+    license: BSD-3-Clause
+    language: C++
 
 - name: PyDy
-  url: "https://www.pydy.org/"
+  url: https://www.pydy.org/
+  description: Multibody dynamics analysis with symbolic Python using SymPy.
   github: pydy/pydy
   license: BSD-3-Clause
-  languages: [Python]
-
+  languages:
+  - Python
+  _meta:
+    stars: 405
+    last_commit: '2025-11-03'
+    license: BSD-3-Clause
+    language: Python
 
 - name: RBDL
-  url: "https://rbdl.github.io/"
+  url: https://rbdl.github.io/
+  description: Rigid Body Dynamics Library based on Featherstone algorithms.
   github: rbdl/rbdl
   license: Zlib
-  languages: [C++, Python]
-  models: [rigid]
-  features: [ik, id, urdf]
-
+  languages:
+  - C++
+  - Python
+  models:
+  - rigid
+  features:
+  - ik
+  - id
+  - urdf
+  _meta:
+    stars: 683
+    last_commit: '2025-06-09'
+    language: C++
 
 - name: RBDyn
+  description: Rigid body dynamics algorithms using spatial algebra with Eigen.
   github: jrl-umi3218/RBDyn
   license: LGPL-3.0
-  languages: [C++, Python]
-  models: [rigid]
-
+  languages:
+  - C++
+  - Python
+  models:
+  - rigid
+  _meta:
+    stars: 211
+    last_commit: '2026-01-20'
+    license: BSD-2-Clause
+    language: C++
 
 - name: RaiSim
-  url: "https://slides.com/jeminhwangbo/raisim-manual"
+  url: https://slides.com/jeminhwangbo/raisim-manual
+  description: Cross-platform physics engine for robotics and reinforcement learning.
   github: leggedrobotics/raisimLib
   license: custom
-  languages: [C++]
-
+  languages:
+  - C++
+  _meta:
+    stars: 329
+    last_commit: '2020-11-26'
+    archived: true
 
 - name: ReactPhysics3d
-  url: "https://www.reactphysics3d.com/"
+  url: https://www.reactphysics3d.com/
+  description: Open-source 3D physics engine for rigid body simulation and collision detection.
   github: DanielChappuis/reactphysics3d
   license: Zlib
-  languages: [C++]
-
+  languages:
+  - C++
+  _meta:
+    stars: 1708
+    last_commit: '2025-03-28'
+    license: Zlib
+    language: C++
 
 - name: RigidBodyDynamics.jl
+  description: Julia library for rigid body dynamics algorithms.
   github: JuliaRobotics/RigidBodyDynamics.jl
   license: MIT "Expat"
-  languages: [Julia]
-  models: [rigid]
-
+  languages:
+  - Julia
+  models:
+  - rigid
+  _meta:
+    stars: 307
+    last_commit: '2024-11-08'
+    language: Julia
 
 - name: Rigs of Rods
-  url: "https://www.rigsofrods.org/"
+  url: https://www.rigsofrods.org/
+  description: Soft-body vehicle simulator using beam physics.
   github: RigsOfRods/rigs-of-rods
   license: GPL-3.0
-  languages: [C++]
-  models: [rigid, soft, vehicle]
-
+  languages:
+  - C++
+  models:
+  - rigid
+  - soft
+  - vehicle
+  _meta:
+    stars: 1149
+    last_commit: '2026-01-18'
+    license: GPL-3.0
+    language: C++
 
 - name: Robopy
-  url: "https://adityadua24.github.io/robopy/"
+  url: https://adityadua24.github.io/robopy/
+  description: Python robotics toolbox inspired by Peter Corke's Robotics Toolbox.
   github: adityadua24/robopy
   license: MIT
-  languages: [Python 3]
-
+  languages:
+  - Python 3
+  _meta:
+    stars: 228
+    last_commit: '2021-02-10'
+    license: MIT
+    language: Python
 
 - name: Robotics Library
-  url: "https://www.roboticslibrary.org/"
+  url: https://www.roboticslibrary.org/
+  description: Self-contained C++ library for robot kinematics, planning, and control.
   github: roboticslibrary/rl
   license: GPL-3.0 or BSD-2-Clause
-  languages: [C++]
-
+  languages:
+  - C++
+  _meta:
+    stars: 1154
+    last_commit: '2025-04-15'
+    license: BSD-2-Clause
+    language: C++
 
 - name: RobWork
-  url: "https://robwork.dk/"
+  url: https://robwork.dk/
+  description: Framework for simulation and control of robot systems.
   gitlab: sdurobotics/RobWork
   license: Apache-2.0
-  languages: [C++]
-
+  languages:
+  - C++
 
 - name: siconos
-  url: "https://nonsmooth.gricad-pages.univ-grenoble-alpes.fr/siconos/"
+  url: https://nonsmooth.gricad-pages.univ-grenoble-alpes.fr/siconos/
+  description: Nonsmooth dynamical systems modeling and simulation platform.
   github: siconos/siconos
   license: Apache-2.0
-  languages: [C++, Python]
-
+  languages:
+  - C++
+  - Python
+  _meta:
+    stars: 182
+    last_commit: '2025-09-19'
+    license: Apache-2.0
+    language: C
 
 - name: Simbody
-  url: "https://simtk.org/home/simbody/"
+  url: https://simtk.org/home/simbody/
+  description: Multibody dynamics library for biomechanical and mechanical systems.
   github: simbody/simbody
   license: Apache-2.0
-  languages: [C++]
-  models: [rigid, molecules]
-  features: [id, urdf]
-
+  languages:
+  - C++
+  models:
+  - rigid
+  - molecules
+  features:
+  - id
+  - urdf
+  _meta:
+    stars: 2495
+    last_commit: '2026-01-31'
+    license: Apache-2.0
+    language: C++
 
 - name: SOFA
-  url: "https://www.sofa-framework.org/"
+  url: https://www.sofa-framework.org/
+  description: Simulation Open Framework Architecture for medical and physics simulation.
   github: sofa-framework/sofa
   license: LGPL-2.1
-  languages: [C++]
-  models: [rigid, soft, medical]
-
+  languages:
+  - C++
+  models:
+  - rigid
+  - soft
+  - medical
+  _meta:
+    stars: 1146
+    last_commit: '2026-02-02'
+    license: LGPL-2.1
+    language: C++
 
 - name: Tiny Differentiable Simulator
+  description: Header-only differentiable physics engine for robotics.
   github: erwincoumans/tiny-differentiable-simulator
   license: Apache-2.0
-  languages: [C++, Python]
-  models: [rigid]
-
+  languages:
+  - C++
+  - Python
+  models:
+  - rigid
+  _meta:
+    stars: 1341
+    last_commit: '2024-10-18'
+    license: Apache-2.0
+    language: C++
 
 - name: trep
-  url: "http://murpheylab.github.io/trep/"
+  url: http://murpheylab.github.io/trep/
+  description: Simulation and optimal control using variational integrators.
   github: MurpheyLab/trep
   license: GPL-3.0
-  languages: [C, Python]
-  models: [rigid]
-  features: [dm, trj-opt]
-
+  languages:
+  - C
+  - Python
+  models:
+  - rigid
+  features:
+  - dm
+  - trj-opt
+  _meta:
+    stars: 20
+    last_commit: '2023-09-03'
+    license: GPL-3.0
+    language: C
 
 - name: qu3e
+  description: Lightweight 3D physics engine for rigid body dynamics.
   github: RandyGaul/qu3e
   license: Zlib
-  languages: [C++]
-  models: [rigid]
-
+  languages:
+  - C++
+  models:
+  - rigid
+  _meta:
+    stars: 974
+    last_commit: '2021-05-09'
+    archived: true
+    license: Zlib
+    language: C

--- a/data/etc.yaml
+++ b/data/etc.yaml
@@ -1,9 +1,10 @@
-# etc
-# Source of truth — edit this file, then run: pixi run generate
-
 - name: fuse
   github: locusrobotics/fuse
   description: General architecture for performing sensor fusion live on a robot.
+  _meta:
+    stars: 847
+    last_commit: '2025-12-30'
+    language: C++
 
 - name: Foxglove Studio
   url: https://foxglove.dev

--- a/data/fluid.yaml
+++ b/data/fluid.yaml
@@ -1,7 +1,9 @@
-# fluid
-# Source of truth — edit this file, then run: pixi run generate
-
 - name: Fluid Engine Dev - Jet
   url: https://fluidenginedevelopment.org/
   github: doyubkim/fluid-engine-dev
   description: Fluid simulation engine for computer graphics applications.
+  _meta:
+    stars: 2067
+    last_commit: '2023-12-24'
+    license: MIT
+    language: C++

--- a/data/grasping.yaml
+++ b/data/grasping.yaml
@@ -1,25 +1,36 @@
-# grasping
-# Source of truth — edit this file, then run: pixi run generate
-
 - name: AnyGrasp SDK
-  url: "https://github.com/graspnet/anygrasp_sdk"
+  url: https://github.com/graspnet/anygrasp_sdk
   github: graspnet/anygrasp_sdk
   description: SDK for AnyGrasp, a 6-DoF grasp pose detection method.
-
+  _meta:
+    stars: 752
+    last_commit: '2025-11-23'
+    language: Python
 
 - name: Contact-GraspNet
-  url: "https://github.com/NVlabs/contact_graspnet"
+  url: https://github.com/NVlabs/contact_graspnet
   github: NVlabs/contact_graspnet
   description: 6-DoF grasp generation for parallel-jaw grippers using contact maps.
-
+  _meta:
+    stars: 449
+    last_commit: '2024-11-21'
+    language: Python
 
 - name: GraspNet API
-  url: "https://github.com/graspnet/graspnetAPI"
+  url: https://github.com/graspnet/graspnetAPI
   github: graspnet/graspnetAPI
   description: Python API and evaluation tools for the GraspNet benchmark.
+  _meta:
+    stars: 323
+    last_commit: '2025-06-16'
+    license: MIT
+    language: Python
 
-
-- name: "GraspIt!"
-  url: "https://graspit-simulator.github.io/"
+- name: GraspIt!
+  url: https://graspit-simulator.github.io/
   github: graspit-simulator/graspit
   description: Simulator for grasping research that can accommodate arbitrary hand and robot designs.
+  _meta:
+    stars: 207
+    last_commit: '2021-04-19'
+    language: C++

--- a/data/humanoid-robotics.yaml
+++ b/data/humanoid-robotics.yaml
@@ -1,19 +1,26 @@
-# humanoid-robotics
-# Source of truth — edit this file, then run: pixi run generate
-
 - name: Humanoid-Gym
-  url: "https://github.com/roboterax/humanoid-gym"
+  url: https://github.com/roboterax/humanoid-gym
   github: roboterax/humanoid-gym
   description: Reinforcement learning environment for humanoid robot locomotion.
-
+  _meta:
+    stars: 1826
+    last_commit: '2025-01-26'
+    language: Python
 
 - name: Legged Gym
-  url: "https://github.com/leggedrobotics/legged_gym"
+  url: https://github.com/leggedrobotics/legged_gym
   github: leggedrobotics/legged_gym
   description: Isaac Gym environments for legged robot locomotion training.
-
+  _meta:
+    stars: 2673
+    last_commit: '2025-05-29'
+    language: Python
 
 - name: MuJoCo Menagerie
-  url: "https://github.com/google-deepmind/mujoco_menagerie"
+  url: https://github.com/google-deepmind/mujoco_menagerie
   github: google-deepmind/mujoco_menagerie
   description: Collection of well-tuned MuJoCo models for research and development.
+  _meta:
+    stars: 3001
+    last_commit: '2026-01-11'
+    language: Python

--- a/data/inverse-kinematics.yaml
+++ b/data/inverse-kinematics.yaml
@@ -1,23 +1,44 @@
-# inverse-kinematics
-# Source of truth — edit this file, then run: pixi run generate
-
 - name: IKBT
   github: uw-biorobotics/IKBT
   description: A python package to solve robot arm inverse kinematics in symbolic form.
+  _meta:
+    stars: 215
+    last_commit: '2026-01-30'
+    language: Python
 
 - name: Kinpy
   github: neka-nat/kinpy
   description: A simple pure python package to solve inverse kinematics.
+  _meta:
+    stars: 179
+    last_commit: '2025-12-20'
+    license: MIT
+    language: Python
 
 - name: Lively
   github: Wisc-HCI/lively
   description: A highly configurable toolkit for commanding robots in mixed modalities.
+  _meta:
+    stars: 7
+    last_commit: '2023-08-15'
+    license: MIT
+    language: Rust
 
 - name: RelaxedIK
   github: uwgraphics/relaxed_ik
   description: Real-time Synthesis of Accurate and Feasible Robot Arm Motion.
+  _meta:
+    stars: 235
+    last_commit: '2023-04-13'
+    license: MIT
+    language: Python
 
 - name: Trip
   url: https://trip-kinematics.readthedocs.io/en/main/index.html
   github: TriPed-Robot/trip_kinematics
   description: A python package that solves inverse kinematics of parallel-, serial- or hybrid-robots.
+  _meta:
+    stars: 44
+    last_commit: '2022-05-06'
+    license: MIT
+    language: Python

--- a/data/machine-learning.yaml
+++ b/data/machine-learning.yaml
@@ -1,75 +1,146 @@
-# machine-learning
-# Source of truth — edit this file, then run: pixi run generate
-
 - name: AllenAct
   url: https://allenact.org/
   github: allenai/allenact
   description: Python/PyTorch-based Research Framework for Embodied AI.
+  _meta:
+    stars: 376
+    last_commit: '2025-08-22'
+    language: Python
 
 - name: Any4LeRobot
   github: Tavish9/any4lerobot
   description: A collection of utilities and tools for LeRobot.
+  _meta:
+    stars: 838
+    last_commit: '2026-01-30'
+    license: MIT
+    language: Python
 
 - name: DLL
   github: wichtounet/dll
   description: Deep Learning Library (DLL) for C++.
+  _meta:
+    stars: 687
+    last_commit: '2025-05-27'
+    license: MIT
+    language: C++
 
 - name: DyNet
   url: https://dynet.readthedocs.io/en/latest/
   github: clab/dynet
   description: The Dynamic Neural Network Toolkit.
+  _meta:
+    stars: 3435
+    last_commit: '2023-12-01'
+    license: Apache-2.0
+    language: C++
 
 - name: Fido
   url: http://fidoproject.github.io/
   github: FidoProject/Fido
   description: Lightweight C++ machine learning library for embedded electronics and robotics.
+  _meta:
+    stars: 462
+    last_commit: '2020-01-05'
+    license: MIT
+    language: C++
 
 - name: Ivy
   url: https://lets-unify.ai/
   github: ivy-llc/ivy
   description: Unified Machine Learning Framework.
+  _meta:
+    stars: 14220
+    last_commit: '2025-10-17'
+    language: Python
 
 - name: LeRobot
   github: huggingface/lerobot
-  description: State-of-the-art approaches, pretrained models, datasets, and simulation environments for real-world robotics in PyTorch.
+  description: State-of-the-art approaches, pretrained models, datasets, and simulation environments for real-world robotics
+    in PyTorch.
+  _meta:
+    stars: 21363
+    last_commit: '2026-02-02'
+    license: Apache-2.0
+    language: Python
 
 - name: LeRobot Episode Scoring Toolkit
   url: https://github.com/RoboticsData/score_lerobot_episodes
   github: RoboticsData/score_lerobot_episodes
   description: One-click tool to score, filter, and export higher-quality LeRobot datasets.
+  _meta:
+    stars: 48
+    last_commit: '2026-01-30'
+    license: Apache-2.0
+    language: Python
 
 - name: MiniDNN
   github: yixuan/MiniDNN
   description: A header-only C++ library for deep neural networks.
+  _meta:
+    stars: 431
+    last_commit: '2021-04-16'
+    language: C++
 
 - name: mlpack
   url: https://www.mlpack.org/
   github: mlpack/mlpack
   description: Scalable C++ machine learning library.
+  _meta:
+    stars: 5590
+    last_commit: '2026-02-01'
+    language: C++
 
 - name: Gymnasium
   url: https://gymnasium.farama.org/
   github: Farama-Foundation/Gymnasium
   description: Developing and comparing reinforcement learning algorithms.
+  _meta:
+    stars: 11232
+    last_commit: '2026-02-02'
+    license: MIT
+    language: Python
 
 - name: gym-dart
   github: DartEnv/dart-env
   description: OpenAI Gym environments using the DART physics engine.
+  _meta:
+    stars: 141
+    last_commit: '2020-10-20'
+    language: Python
 
 - name: gym-gazebo
   github: erlerobot/gym-gazebo
   description: OpenAI Gym environments for the Gazebo simulator.
+  _meta:
+    stars: 845
+    last_commit: '2019-03-16'
+    archived: true
+    license: GPL-3.0
+    language: Python
 
 - name: RLLib
   github: samindaa/RLLib
   description: Temporal-difference learning algorithms in reinforcement learning.
+  _meta:
+    stars: 208
+    last_commit: '2016-08-15'
+    language: C++
 
 - name: robosuite
   url: https://robosuite.ai
   github: ARISE-Initiative/robosuite
   description: A modular simulation framework and benchmark for robot learning.
+  _meta:
+    stars: 2184
+    last_commit: '2026-01-31'
+    language: Python
 
 - name: tiny-dnn
   url: http://tiny-dnn.readthedocs.io/en/latest/
   github: tiny-dnn/tiny-dnn
   description: Header only, dependency-free deep learning framework in C++14.
+  _meta:
+    stars: 6016
+    last_commit: '2022-04-17'
+    language: C++

--- a/data/math.yaml
+++ b/data/math.yaml
@@ -1,26 +1,53 @@
-# math
-# Source of truth — edit this file, then run: pixi run generate
-
 - name: Fastor
   github: romeric/Fastor
   description: Light-weight high performance tensor algebra framework in C++11/14/17.
+  _meta:
+    stars: 830
+    last_commit: '2025-07-08'
+    license: MIT
+    language: C++
 
 - name: linalg.h
   github: sgorsten/linalg
   description: Single header public domain linear algebra library for C++11.
+  _meta:
+    stars: 939
+    last_commit: '2023-07-02'
+    license: Unlicense
+    language: C++
 
 - name: manif
   github: artivis/manif
   description: Small c++11 header-only library for Lie theory.
+  _meta:
+    stars: 1725
+    last_commit: '2025-11-01'
+    license: MIT
+    language: C++
 
 - name: Sophus
   github: strasdat/Sophus
   description: Lie groups using Eigen.
+  _meta:
+    stars: 2366
+    last_commit: '2024-07-06'
+    language: C++
 
 - name: SpaceVelAlg
   github: jrl-umi3218/SpaceVecAlg
   description: Spatial vector algebra with the Eigen3.
+  _meta:
+    stars: 80
+    last_commit: '2025-12-23'
+    license: BSD-2-Clause
+    language: C++
 
 - name: spatialmath-python
   github: bdaiinstitute/spatialmath-python
-  description: A python package provides classes to represent pose and orientation in 3D and 2D space, along with a toolbox of spatial operations.
+  description: A python package provides classes to represent pose and orientation in 3D and 2D space, along with a toolbox
+    of spatial operations.
+  _meta:
+    stars: 615
+    last_commit: '2025-11-20'
+    license: MIT
+    language: Python

--- a/data/motion-planning.yaml
+++ b/data/motion-planning.yaml
@@ -1,14 +1,21 @@
-# motion-planning
-# Source of truth — edit this file, then run: pixi run generate
-
 - name: AIKIDO
   url: https://github.com/personalrobotics/aikido
   github: personalrobotics/aikido
   description: Solving robotic motion planning and decision making problems.
+  _meta:
+    stars: 228
+    last_commit: '2023-03-10'
+    license: BSD-3-Clause
+    language: C++
 
 - name: Bioptim
   github: pyomeca/bioptim
   description: Bioptim, a Python Framework for Musculoskeletal Optimal Control in Biomechanics.
+  _meta:
+    stars: 113
+    last_commit: '2026-01-30'
+    license: MIT
+    language: Python
 
 - name: CuiKSuite
   url: http://www.iri.upc.edu/people/porta/Soft/CuikSuite2-Doc/html
@@ -18,23 +25,46 @@
   url: https://curobo.org
   github: nvlabs/curobo
   description: A CUDA accelerated library containing a suite of robotics algorithms that run significantly faster.
+  _meta:
+    stars: 1340
+    last_commit: '2025-10-23'
+    language: Python
 
 - name: Control Toolbox
   url: https://ethz-adrl.github.io/ct/
   github: ethz-adrl/control-toolbox
   description: Open-Source C++ Library for Robotics, Optimal and Model Predictive Control.
+  _meta:
+    stars: 1656
+    last_commit: '2022-11-09'
+    license: BSD-2-Clause
+    language: C++
 
 - name: Crocoddyl
   github: loco-3d/crocoddyl
   description: Optimal control library for robot control under contact sequence.
+  _meta:
+    stars: 1157
+    last_commit: '2026-01-30'
+    license: BSD-3-Clause
+    language: C++
 
 - name: Fields2Cover
   github: fields2cover/fields2cover
   description: Robust and efficient coverage paths for autonomous agricultural vehicles.
+  _meta:
+    stars: 745
+    last_commit: '2026-01-09'
+    license: BSD-3-Clause
+    language: C++
 
 - name: GPMP2
   github: gtrll/gpmp2
   description: Gaussian Process Motion Planner 2.
+  _meta:
+    stars: 351
+    last_commit: '2022-08-28'
+    language: C++
 
 - name: HPP
   url: https://humanoid-path-planner.github.io/hpp-doc/
@@ -44,71 +74,138 @@
   url: https://moveit.ai/
   github: moveit/moveit
   description: Motion planning framework.
+  _meta:
+    stars: 2001
+    last_commit: '2026-01-28'
+    license: BSD-3-Clause
+    language: C++
 
 - name: OMPL
   url: https://ompl.kavrakilab.org/
   github: ompl/ompl
   description: Open motion planning library.
+  _meta:
+    stars: 1945
+    last_commit: '2026-01-31'
+    language: C++
 
 - name: OCS2
   github: leggedrobotics/ocs2
   description: Efficient continuous and discrete time optimal control implementation.
+  _meta:
+    stars: 1275
+    last_commit: '2025-12-30'
+    license: BSD-3-Clause
+    language: C++
 
 - name: pymanoid
   github: stephane-caron/pymanoid
   description: Humanoid robotics prototyping environment based on OpenRAVE.
+  _meta:
+    stars: 232
+    last_commit: '2024-02-19'
+    archived: true
+    license: GPL-3.0
+    language: Python
 
 - name: ROS Behavior Tree
   github: miccol/ROS-Behavior-Tree
   description: Behavior tree implementation for ROS-based robot task planning.
+  _meta:
+    stars: 362
+    last_commit: '2018-10-22'
+    license: MIT
+    language: C++
 
 - name: Ruckig
   url: https://github.com/pantor/ruckig
   github: pantor/ruckig
   description: Real-time, time-optimal and jerk-constrained online trajectory generation.
+  _meta:
+    stars: 1116
+    last_commit: '2025-12-31'
+    license: MIT
+    language: C++
 
 - name: The Kautham Project
   url: https://sir.upc.es/projects/kautham/
   github: iocroblab/kautham
   description: A robot simulation toolkit for motion planning.
+  _meta:
+    stars: 24
+    last_commit: '2025-10-22'
+    language: C++
 
 - name: TOPP-RA
   url: https://hungpham2511.github.io/toppra/
   github: hungpham2511/toppra
   description: Time-parameterizing robot trajectories subject to kinematic and dynamic constraints.
+  _meta:
+    stars: 830
+    last_commit: '2026-01-27'
+    license: MIT
+    language: Python
 
 - name: Ungar
   url: https://github.com/fdevinc/ungar
   github: fdevinc/ungar
   description: Expressive and efficient implementation of optimal control problems using template metaprogramming.
+  _meta:
+    stars: 109
+    last_commit: '2024-07-16'
+    license: Apache-2.0
+    language: C++
 
 - name: TopiCo
   github: AIS-Bonn/TopiCo
   description: Time-optimal Trajectory Generation and Control.
   _subsection: Motion Optimizer
+  _meta:
+    stars: 143
+    last_commit: '2021-07-12'
+    license: BSD-3-Clause
+    language: C++
 
 - name: towr
   url: http://wiki.ros.org/towr
   github: ethz-adrl/towr
   description: A light-weight, Eigen-based C++ library for trajectory optimization for legged robots.
   _subsection: Motion Optimizer
+  _meta:
+    stars: 1047
+    last_commit: '2023-04-17'
+    license: BSD-3-Clause
+    language: C++
 
 - name: TrajectoryOptimization
   github: RoboticExplorationLab/TrajectoryOptimization.jl
   description: A fast trajectory optimization library written in Julia.
   _subsection: Motion Optimizer
+  _meta:
+    stars: 386
+    last_commit: '2025-03-27'
+    license: MIT
+    language: Julia
 
 - name: trajopt
   url: http://rll.berkeley.edu/trajopt/doc/sphinx_build/html/
   github: joschu/trajopt
   description: Framework for generating robot trajectories by local optimization.
   _subsection: Motion Optimizer
+  _meta:
+    stars: 449
+    last_commit: '2022-12-05'
+    language: C++
 
 - name: Cover-Tree
   url: http://hunch.net/~jl/projects/cover_tree/cover_tree.html
   github: DNCrane/Cover-Tree
   description: Cover tree data structure for quick k-nearest-neighbor search.
   _subsection: Nearest Neighbor
+  _meta:
+    stars: 64
+    last_commit: '2018-02-13'
+    language: C++
 
 - name: Faster cover trees
   url: http://proceedings.mlr.press/v37/izbicki15.pdf
@@ -120,51 +217,92 @@
   github: flann-lib/flann
   description: Fast Library for Approximate Nearest Neighbors.
   _subsection: Nearest Neighbor
+  _meta:
+    stars: 2363
+    last_commit: '2024-07-29'
+    language: C++
 
 - name: nanoflann
   url: http://www.cs.ubc.ca/research/flann/
   github: jlblancoc/nanoflann
   description: Nearest Neighbor search with KD-trees.
   _subsection: Nearest Neighbor
+  _meta:
+    stars: 2576
+    last_commit: '2025-12-26'
+    language: C++
 
 - name: libpointmatcher
   url: http://libpointmatcher.readthedocs.io/en/latest/
   github: norlab-ulaval/libpointmatcher
   description: Iterative Closest Point library for 2-D/3-D mapping in Robotics.
   _subsection: 3D Mapping
+  _meta:
+    stars: 1782
+    last_commit: '2025-10-29'
+    license: BSD-3-Clause
+    language: C++
 
 - name: Octree
   github: jbehley/octree
   description: Fast radius neighbor search with an Octree.
   _subsection: 3D Mapping
+  _meta:
+    stars: 374
+    last_commit: '2019-12-17'
+    license: MIT
+    language: C++
 
 - name: OctoMap
   url: http://octomap.github.io/
   github: OctoMap/octomap
   description: Efficient Probabilistic 3D Mapping Framework Based on Octrees.
   _subsection: 3D Mapping
+  _meta:
+    stars: 2261
+    last_commit: '2026-01-05'
+    language: C++
 
 - name: PCL
   url: https://pointclouds.org/
   github: PointCloudLibrary/pcl
   description: 2D/3D image and point cloud processing.
   _subsection: 3D Mapping
+  _meta:
+    stars: 10846
+    last_commit: '2026-02-01'
+    language: C++
 
 - name: Bonxai
   github: facontidavide/Bonxai
   description: Brutally fast, sparse, 3D Voxel Grid (formerly Treexy).
   _subsection: 3D Mapping
+  _meta:
+    stars: 810
+    last_commit: '2025-10-20'
+    license: MPL-2.0
+    language: C++
 
 - name: voxblox
   github: ethz-asl/voxblox
   description: Flexible voxel-based mapping focusing on truncated and Euclidean signed distance fields.
   _subsection: 3D Mapping
+  _meta:
+    stars: 1580
+    last_commit: '2024-07-01'
+    license: BSD-3-Clause
+    language: C++
 
 - name: wavemap
   url: https://projects.asl.ethz.ch/wavemap/
   github: ethz-asl/wavemap
   description: Fast, efficient and accurate multi-resolution, multi-sensor 3D occupancy mapping.
   _subsection: 3D Mapping
+  _meta:
+    stars: 551
+    last_commit: '2024-12-30'
+    license: BSD-3-Clause
+    language: C++
 
 - name: Utility Software
   _subsection: 3D Mapping
@@ -174,3 +312,8 @@
   github: guillaumechereau/goxel
   description: Free and open source 3D voxel editor.
   _subsection: 3D Mapping
+  _meta:
+    stars: 3075
+    last_commit: '2026-01-20'
+    license: GPL-3.0
+    language: C++

--- a/data/multiphysics.yaml
+++ b/data/multiphysics.yaml
@@ -1,7 +1,8 @@
-# multiphysics
-# Source of truth — edit this file, then run: pixi run generate
-
 - name: Kratos
   url: http://www.cimne.com/kratos/
   github: KratosMultiphysics/Kratos
   description: Framework for building parallel multi-disciplinary simulation software.
+  _meta:
+    stars: 1219
+    last_commit: '2026-02-02'
+    language: C++

--- a/data/optimization.yaml
+++ b/data/optimization.yaml
@@ -1,103 +1,202 @@
-# optimization
-# Source of truth — edit this file, then run: pixi run generate
-
 - name: CasADi
   url: https://github.com/casadi/casadi/wiki
   github: casadi/casadi
   description: Symbolic framework for algorithmic differentiation and numeric optimization.
+  _meta:
+    stars: 2125
+    last_commit: '2026-02-02'
+    license: LGPL-3.0
+    language: C++
 
 - name: Ceres Solver
   url: http://ceres-solver.org/
   github: ceres-solver/ceres-solver
   description: Large scale nonlinear optimization library.
+  _meta:
+    stars: 4402
+    last_commit: '2026-02-01'
+    language: C++
 
 - name: eigen-qld
   github: jrl-umi3218/eigen-qld
   description: Interface to use the QLD QP solver with the Eigen3 library.
+  _meta:
+    stars: 16
+    last_commit: '2025-12-23'
+    license: BSD-2-Clause
+    language: C
 
 - name: EXOTica
   github: ipab-slmc/exotica
   description: Generic optimisation toolset for robotics platforms.
+  _meta:
+    stars: 161
+    last_commit: '2024-08-14'
+    license: BSD-3-Clause
+    language: C++
 
 - name: hpipm
   github: giaf/hpipm
   description: High-performance interior-point-method QP solvers (Ipopt, Snopt).
+  _meta:
+    stars: 665
+    last_commit: '2025-12-27'
+    language: C
 
 - name: HYPRE
   url: https://hypre.readthedocs.io/
   github: hypre-space/hypre
   description: Parallel solvers for sparse linear systems featuring multigrid methods.
+  _meta:
+    stars: 812
+    last_commit: '2026-02-02'
+    language: C
 
 - name: ifopt
   github: ethz-adrl/ifopt
   description: An Eigen-based, light-weight C++ Interface to Nonlinear Programming Solvers (Ipopt, Snopt).
+  _meta:
+    stars: 847
+    last_commit: '2025-11-03'
+    license: BSD-3-Clause
+    language: C++
 
 - name: Ipopt
   url: https://projects.coin-or.org/Ipopt
   github: coin-or/Ipopt
   description: Large scale nonlinear optimization library.
+  _meta:
+    stars: 1699
+    last_commit: '2026-02-01'
+    license: EPL-2.0
+    language: C++
 
 - name: libcmaes
   github: CMA-ES/libcmaes
   description: Blackbox stochastic optimization using the CMA-ES algorithm.
+  _meta:
+    stars: 354
+    last_commit: '2025-09-15'
+    language: C++
 
 - name: limbo
   url: http://www.resibots.eu/limbo/
   github: resibots/limbo
   description: Gaussian processes and Bayesian optimization of black-box functions.
+  _meta:
+    stars: 260
+    last_commit: '2023-10-18'
+    language: C++
 
 - name: lpsolvers
   github: stephane-caron/lpsolvers
   description: Linear Programming solvers in Python with a unified API.
+  _meta:
+    stars: 25
+    last_commit: '2025-04-09'
+    license: LGPL-3.0
+    language: Python
 
 - name: NLopt
   url: https://nlopt.readthedocs.io/en/latest/
   github: stevengj/nlopt
   description: Nonlinear optimization.
+  _meta:
+    stars: 2175
+    last_commit: '2025-12-17'
+    language: C
 
 - name: OptimLib
   url: https://www.kthohr.com/optimlib.html
   github: kthohr/optim
   description: Lightweight C++ library of numerical optimization methods for nonlinear functions.
+  _meta:
+    stars: 885
+    last_commit: '2024-04-28'
+    license: Apache-2.0
+    language: C++
 
 - name: OSQP
   url: https://osqp.org/
   github: osqp/osqp
   description: The Operator Splitting QP Solver.
+  _meta:
+    stars: 2059
+    last_commit: '2026-01-12'
+    license: Apache-2.0
+    language: C
 
 - name: Pagmo
   url: https://esa.github.io/pagmo2/index.html
   github: esa/pagmo2
   description: Scientific library for massively parallel optimization.
+  _meta:
+    stars: 907
+    last_commit: '2025-10-28'
+    license: GPL-3.0
+    language: C++
 
 - name: ProxSuite
   url: https://simple-robotics.github.io/proxsuite/
   github: Simple-Robotics/ProxSuite
   description: The Advanced Proximal Optimization Toolbox.
+  _meta:
+    stars: 538
+    last_commit: '2026-02-02'
+    license: BSD-2-Clause
+    language: C++
 
 - name: pymoo
   url: https://www.pymoo.org/
   github: msu-coinlab/pymoo
   description: Multi-objective Optimization in Python.
+  _meta:
+    stars: 26
+    last_commit: '2023-04-19'
+    license: Apache-2.0
 
 - name: qpsolvers
   github: qpsolvers/qpsolvers
   description: Quadratic Programming solvers in Python with a unified API.
+  _meta:
+    stars: 725
+    last_commit: '2025-12-08'
+    license: LGPL-3.0
+    language: Python
 
 - name: RobOptim
   url: http://roboptim.net/index.html
   github: roboptim/roboptim-core
   description: Numerical Optimization for Robotics.
+  _meta:
+    stars: 65
+    last_commit: '2025-03-21'
+    license: LGPL-3.0
+    language: C++
 
 - name: SCS
   url: http://web.stanford.edu/~boyd/papers/scs.html
   github: cvxgrp/scs
   description: Numerical optimization for solving large-scale convex cone problems.
+  _meta:
+    stars: 613
+    last_commit: '2026-01-09'
+    license: MIT
+    language: C
 
 - name: SHOT
   github: coin-or/SHOT
   description: A solver for mixed-integer nonlinear optimization problems.
+  _meta:
+    stars: 129
+    last_commit: '2026-01-12'
+    license: EPL-2.0
+    language: C++
 
 - name: sferes2
   github: sferes2/sferes2
   description: Evolutionary computation.
+  _meta:
+    stars: 170
+    last_commit: '2022-07-11'
+    language: C++

--- a/data/other-awesome-lists.yaml
+++ b/data/other-awesome-lists.yaml
@@ -1,58 +1,103 @@
-# other-awesome-lists
-# Source of truth — edit this file, then run: pixi run generate
-
 - name: Awesome Robotics
   url: https://github.com/Kiloreux/awesome-robotics
   github: Kiloreux/awesome-robotics
   description: (Kiloreux).
+  _meta:
+    stars: 6007
+    last_commit: '2024-09-22'
 
 - name: Awesome Robotics
   url: https://github.com/ahundt/awesome-robotics
   github: ahundt/awesome-robotics
   description: (ahundt).
+  _meta:
+    stars: 1322
+    last_commit: '2024-01-10'
 
 - name: Awesome Robotic Tooling
   url: https://github.com/Ly0n/awesome-robotic-tooling
   github: Ly0n/awesome-robotic-tooling
+  _meta:
+    stars: 3722
+    last_commit: '2023-11-20'
+    license: CC0-1.0
 
 - name: Awesome Artificial Intelligence
   url: https://github.com/owainlewis/awesome-artificial-intelligence
   github: owainlewis/awesome-artificial-intelligence
+  _meta:
+    stars: 12923
+    last_commit: '2025-08-12'
+    license: MIT
 
 - name: Awesome Collision Detection
   url: https://github.com/jslee02/awesome-collision-detection
   github: jslee02/awesome-collision-detection
+  _meta:
+    stars: 999
+    last_commit: '2023-09-30'
+    license: CC0-1.0
 
 - name: Awesome Computer Vision
   url: https://github.com/jbhuang0604/awesome-computer-vision
   github: jbhuang0604/awesome-computer-vision
+  _meta:
+    stars: 23033
+    last_commit: '2024-05-17'
 
 - name: Awesome Machine Learning
   url: https://github.com/josephmisiti/awesome-machine-learning
   github: josephmisiti/awesome-machine-learning
+  _meta:
+    stars: 71565
+    last_commit: '2026-01-29'
+    language: Python
 
 - name: Awesome Deep Learning
   url: https://github.com/ChristosChristofidis/awesome-deep-learning
   github: ChristosChristofidis/awesome-deep-learning
+  _meta:
+    stars: 27443
+    last_commit: '2025-05-26'
 
 - name: Awesome Gazebo
   url: https://github.com/fkromer/awesome-gazebo
   github: fkromer/awesome-gazebo
+  _meta:
+    stars: 153
+    last_commit: '2021-01-24'
+    archived: true
 
 - name: Awesome Grasping
   url: https://github.com/Po-Jen/awesome-grasping
   github: Po-Jen/awesome-grasping
+  _meta:
+    stars: 96
+    last_commit: '2019-07-13'
+    license: Unlicense
 
 - name: Awesome Human Robot Interaction
   url: https://github.com/Po-Jen/awesome-human-robot-interaction
   github: Po-Jen/awesome-human-robot-interaction
+  _meta:
+    stars: 147
+    last_commit: '2019-02-12'
+    license: MIT
 
 - name: PythonRobotics
   url: https://github.com/AtsushiSakai/PythonRobotics
   github: AtsushiSakai/PythonRobotics
   description: Python sample codes for robotics algorithms.
+  _meta:
+    stars: 28485
+    last_commit: '2026-01-27'
+    language: Python
 
 - name: Robotics Coursework
   url: https://github.com/mithi/robotics-coursework
   github: mithi/robotics-coursework
   description: A list of robotics courses you can take online.
+  _meta:
+    stars: 3906
+    last_commit: '2026-01-24'
+    license: Unlicense

--- a/data/reinforcement-learning.yaml
+++ b/data/reinforcement-learning.yaml
@@ -1,25 +1,38 @@
-# reinforcement-learning
-# Source of truth — edit this file, then run: pixi run generate
-
 - name: CleanRL
-  url: "https://github.com/vwxyzjn/cleanrl"
+  url: https://github.com/vwxyzjn/cleanrl
   github: vwxyzjn/cleanrl
   description: Single-file implementations of deep reinforcement learning algorithms.
-
+  _meta:
+    stars: 9019
+    last_commit: '2025-07-08'
+    language: Python
 
 - name: rl_games
-  url: "https://github.com/Denys88/rl_games"
+  url: https://github.com/Denys88/rl_games
   github: Denys88/rl_games
   description: High-performance RL library used in Isaac Gym environments.
-
+  _meta:
+    stars: 1290
+    last_commit: '2026-01-30'
+    license: MIT
+    language: Jupyter Notebook
 
 - name: SKRL
-  url: "https://github.com/Toni-SM/skrl"
+  url: https://github.com/Toni-SM/skrl
   github: Toni-SM/skrl
   description: Modular reinforcement learning library with support for multiple ML frameworks.
-
+  _meta:
+    stars: 982
+    last_commit: '2026-01-25'
+    license: MIT
+    language: Python
 
 - name: Stable-Baselines3
-  url: "https://github.com/DLR-RM/stable-baselines3"
+  url: https://github.com/DLR-RM/stable-baselines3
   github: DLR-RM/stable-baselines3
   description: Reliable implementations of reinforcement learning algorithms in PyTorch.
+  _meta:
+    stars: 12676
+    last_commit: '2026-01-23'
+    license: MIT
+    language: Python

--- a/data/robot-modeling.yaml
+++ b/data/robot-modeling.yaml
@@ -1,6 +1,3 @@
-# robot-modeling
-# Source of truth — edit this file, then run: pixi run generate
-
 - name: SDF
   url: http://sdformat.org/
   bitbucket: osrf/sdformat
@@ -12,14 +9,28 @@
   github: ros/urdfdom
   description: XML format for representing a robot model.
   _subsection: Robot Model Description Format
+  _meta:
+    stars: 118
+    last_commit: '2025-12-26'
+    language: C++
 
 - name: onshape-to-robot
   url: https://github.com/Rhoban/onshape-to-robot
   github: Rhoban/onshape-to-robot
   description: Converting OnShape assembly to robot definition (SDF or URDF) through OnShape API.
   _subsection: Utility to Build Robot Models
+  _meta:
+    stars: 486
+    last_commit: '2026-02-02'
+    license: MIT
+    language: Python
 
 - name: phobos
   github: dfki-ric/phobos
   description: Add-on for Blender creating URDF and SMURF robot models.
   _subsection: Utility to Build Robot Models
+  _meta:
+    stars: 855
+    last_commit: '2025-07-30'
+    license: BSD-3-Clause
+    language: Python

--- a/data/robot-platform.yaml
+++ b/data/robot-platform.yaml
@@ -1,24 +1,39 @@
-# robot-platform
-# Source of truth — edit this file, then run: pixi run generate
-
 - name: AutoRally
   url: http://autorally.github.io/
   github: autorally/autorally
   description: High-performance testbed for advanced perception and control research.
+  _meta:
+    stars: 775
+    last_commit: '2023-03-03'
+    language: C++
 
 - name: Linorobot
   url: https://linorobot.org/
   github: linorobot/linorobot
   description: ROS compatible ground robots.
+  _meta:
+    stars: 1080
+    last_commit: '2023-05-10'
+    license: BSD-2-Clause
+    language: C++
 
 - name: onine
   github: grassjelly/onine
   description: Service Robot based on Linorobot and Braccio Arm.
+  _meta:
+    stars: 47
+    last_commit: '2018-09-19'
+    language: C++
 
 - name: Micro-ROS for Arduino
   url: https://github.com/kaiaai/micro_ros_arduino_kaiaai
   github: kaiaai/micro_ros_arduino_kaiaai
   description: a Micro-ROS fork available in the Arduino Library Manager.
+  _meta:
+    stars: 12
+    last_commit: '2024-10-28'
+    license: Apache-2.0
+    language: C
 
 - name: Rock
   url: https://www.rock-robotics.org/
@@ -32,8 +47,15 @@
   url: https://github.com/ros2/ros2/wiki
   github: ros2/ros2
   description: Version 2.0 of the Robot Operating System (ROS) software stack.
+  _meta:
+    stars: 5028
+    last_commit: '2026-01-28'
 
 - name: YARP
   url: https://www.yarp.it/
   github: robotology/yarp
   description: Communication and device interfaces applicable from humanoids to embedded devices.
+  _meta:
+    stars: 585
+    last_commit: '2026-02-02'
+    language: C++

--- a/data/simulators.yaml
+++ b/data/simulators.yaml
@@ -1,76 +1,129 @@
-# simulators
-# Source of truth — edit this file, then run: pixi run generate
-
 - name: AI2-THOR
   url: https://ai2thor.allenai.org/
   github: allenai/ai2thor
-  description: Python framework with a Unity backend, providing interaction, navigation, and manipulation support for household based robotic agents.
+  description: Python framework with a Unity backend, providing interaction, navigation, and manipulation support for household
+    based robotic agents.
   _subsection: Free or Open Source
+  _meta:
+    stars: 1652
+    last_commit: '2025-11-04'
+    license: Apache-2.0
+    language: C#
 
 - name: AirSim
   github: Microsoft/AirSim
   description: Simulator based on Unreal Engine for autonomous vehicles.
   _subsection: Free or Open Source
+  _meta:
+    stars: 17921
+    last_commit: '2025-05-15'
+    language: C++
 
 - name: ARGoS
   url: https://www.argos-sim.info/
   github: ilpincy/argos3
   description: Physics-based simulator designed to simulate large-scale robot swarms.
   _subsection: Free or Open Source
+  _meta:
+    stars: 301
+    last_commit: '2025-05-03'
+    language: C++
 
 - name: ARTE
   url: http://arvc.umh.es/arte/index_en.html
   github: 4rtur1t0/ARTE
   description: Matlab toolbox focussed on robotic manipulators.
   _subsection: Free or Open Source
+  _meta:
+    stars: 101
+    last_commit: '2025-10-27'
+    language: MATLAB
 
 - name: AVIS Engine
   url: https://avisengine.com
   github: AvisEngine/AVIS-Engine-Python-API
-  description: Autonomous Vehicles Intelligent simulation software, A Fast and robust simulator software for Autonomous vehicle development.
+  description: Autonomous Vehicles Intelligent simulation software, A Fast and robust simulator software for Autonomous vehicle
+    development.
   _subsection: Free or Open Source
+  _meta:
+    stars: 21
+    last_commit: '2025-05-20'
+    language: Python
 
 - name: CARLA
   url: https://carla.org/
   github: carla-simulator/carla
   description: Open-source simulator for autonomous driving research.
   _subsection: Free or Open Source
+  _meta:
+    stars: 13546
+    last_commit: '2026-02-02'
+    license: MIT
+    language: C++
 
 - name: CoppeliaSim
   url: https://www.coppeliarobotics.com/
   github: CoppeliaRobotics/CoppeliaSimLib
   description: Formaly V-REP. Virtual robot experimentation platform.
   _subsection: Free or Open Source
+  _meta:
+    stars: 138
+    last_commit: '2026-02-02'
+    language: C++
 
 - name: Gazebo
   url: https://gazebosim.org/
   github: gazebosim/gazebo-classic
   description: Dynamic multi-robot simulator.
   _subsection: Free or Open Source
+  _meta:
+    stars: 1324
+    last_commit: '2024-12-03'
+    archived: true
+    language: C++
 
 - name: GraspIt!
   url: http://graspit-simulator.github.io/
   github: graspit-simulator/graspit
   description: Simulator for grasping research that can accommodate arbitrary hand and robot designs.
   _subsection: Free or Open Source
+  _meta:
+    stars: 207
+    last_commit: '2021-04-19'
+    language: C++
 
 - name: Habitat-Sim
   url: https://aihabitat.org/
   github: facebookresearch/habitat-sim
   description: Simulation platform for research in embodied artificial intelligence.
   _subsection: Free or Open Source
+  _meta:
+    stars: 3508
+    last_commit: '2026-02-02'
+    license: MIT
+    language: C++
 
 - name: Hexapod Robot Simulator
   url: https://hexapod.netlify.app/
   github: mithi/hexapod
   description: Open-source hexapod robot inverse kinematics and gaits visualizer.
   _subsection: Free or Open Source
+  _meta:
+    stars: 681
+    last_commit: '2026-01-22'
+    license: Apache-2.0
+    language: JavaScript
 
 - name: Gazebo Sim
   url: https://gazebosim.org/
   github: gazebosim/gz-sim
   description: Open source robotics simulator (formerly Ignition Gazebo).
   _subsection: Free or Open Source
+  _meta:
+    stars: 1191
+    last_commit: '2026-01-31'
+    license: Apache-2.0
+    language: C++
 
 - name: Isaac Sim
   url: https://developer.nvidia.com/isaac/sim
@@ -82,12 +135,21 @@
   github: haosulab/ManiSkill
   description: A robot simulation and behavior learning package powered by SAPIEN, with a strong focus on manipulation skills.
   _subsection: Free or Open Source
+  _meta:
+    stars: 2524
+    last_commit: '2026-01-31'
+    license: Apache-2.0
+    language: Python
 
 - name: MORSE
   url: http://morse-simulator.github.io/
   github: morse-simulator/morse
   description: Modular open robots simulation engine.
   _subsection: Free or Open Source
+  _meta:
+    stars: 370
+    last_commit: '2022-05-13'
+    language: C
 
 - name: Neurorobotics Platform
   url: https://neurorobotics.net/
@@ -100,28 +162,48 @@
   github: bulletphysics/bullet3
   description: An easy to use simulator for robotics and deep reinforcement learning.
   _subsection: Free or Open Source
+  _meta:
+    stars: 14206
+    last_commit: '2025-10-22'
+    language: C++
 
 - name: PyBullet_Industrial
   url: https://pybullet-industrial.readthedocs.io/en/latest/
   github: WBK-Robotics/pybullet_industrial
-  description: A extension to PyBullet that allows for the simulation of various robotic manufacturing processes such as milling or 3D-printing.
+  description: A extension to PyBullet that allows for the simulation of various robotic manufacturing processes such as milling
+    or 3D-printing.
   _subsection: Free or Open Source
+  _meta:
+    stars: 48
+    last_commit: '2025-06-17'
+    license: MIT
+    language: Python
 
 - name: Robot Gui
   url: http://robot.glumb.de/
   github: glumb/robot-gui
   description: A three.js based 3D robot interface.
   _subsection: Free or Open Source
+  _meta:
+    stars: 384
+    last_commit: '2023-06-26'
+    license: MIT
+    language: JavaScript
 
 - name: SAPIEN
   url: https://sapien.ucsd.edu
   github: haosulab/SAPIEN
   description: A realistic and physics-rich simulated environment that hosts a large-scale set for articulated objects.
   _subsection: Free or Open Source
+  _meta:
+    stars: 714
+    last_commit: '2026-02-02'
+    language: C++
 
 - name: Simbad
   url: http://simbad.sourceforge.net/
-  description: A Java 3D robot simulator, enables to write own robot controller with modifying environment using available sensors.
+  description: A Java 3D robot simulator, enables to write own robot controller with modifying environment using available
+    sensors.
   _subsection: Free or Open Source
 
 - name: Unity
@@ -129,12 +211,21 @@
   github: Unity-Technologies/Unity-Robotics-Hub
   description: Popular game engine that now offers open-source tools, tutorials, and resources for robotics simulation.
   _subsection: Free or Open Source
+  _meta:
+    stars: 2456
+    last_commit: '2024-11-26'
+    language: C#
 
 - name: Webots
   url: http://www.cyberbotics.com/
   github: cyberbotics/webots
   description: A complete development environment to model, program and simulate robots, vehicles and mechanical systems.
   _subsection: Free or Open Source
+  _meta:
+    stars: 4073
+    last_commit: '2026-01-30'
+    license: Apache-2.0
+    language: C++
 
 - name: Actin Simulation
   url: http://www.energid.com/

--- a/data/slam.yaml
+++ b/data/slam.yaml
@@ -1,57 +1,106 @@
-# slam
-# Source of truth — edit this file, then run: pixi run generate
-
 - name: AprilSAM
   github: xipengwang/AprilSAM
   description: Real-time smoothing and mapping.
+  _meta:
+    stars: 239
+    last_commit: '2021-07-17'
+    license: LGPL-2.1
+    language: C
 
 - name: Cartographer
   github: cartographer-project/cartographer
   description: Real-time SLAM in 2D and 3D across multiple platforms and sensor configurations.
+  _meta:
+    stars: 7768
+    last_commit: '2024-01-05'
+    license: Apache-2.0
+    language: C++
 
 - name: DSO
   url: https://vision.in.tum.de/research/vslam/dso
   github: JakobEngel/dso
   description: Novel direct and sparse formulation for Visual Odometry.
+  _meta:
+    stars: 2431
+    last_commit: '2024-02-23'
+    license: GPL-3.0
+    language: C++
 
 - name: ElasticFusion
   github: mp3guy/ElasticFusion
   description: Real-time dense visual SLAM system.
+  _meta:
+    stars: 1910
+    last_commit: '2025-08-03'
+    language: C++
 
 - name: fiducials
   url: http://wiki.ros.org/fiducials
   github: UbiquityRobotics/fiducials
   description: Simultaneous localization and mapping using fiducial markers.
+  _meta:
+    stars: 278
+    last_commit: '2025-11-27'
+    license: BSD-3-Clause
+    language: C
 
 - name: GTSAM
   github: borglab/gtsam
   description: Smoothing and mapping (SAM) in robotics and vision.
+  _meta:
+    stars: 3280
+    last_commit: '2026-02-02'
+    language: Jupyter Notebook
 
 - name: Kintinuous
   github: mp3guy/Kintinuous
   description: Real-time large scale dense visual SLAM system.
+  _meta:
+    stars: 951
+    last_commit: '2022-08-26'
+    language: C++
 
 - name: LSD-SLAM
   url: https://vision.in.tum.de/research/vslam/lsdslam
   github: tum-vision/lsd_slam
   description: Real-time monocular SLAM.
+  _meta:
+    stars: 2703
+    last_commit: '2023-03-23'
+    license: GPL-3.0
+    language: C++
 
 - name: ORB-SLAM2
   github: raulmur/ORB_SLAM2
   description: Real-time SLAM library for Monocular, Stereo and RGB-D cameras.
+  _meta:
+    stars: 10085
+    last_commit: '2024-05-15'
+    language: C++
 
 - name: RTAP-Map
   url: http://introlab.github.io/rtabmap/
   github: introlab/rtabmap
   description: RGB-D Graph SLAM approach based on a global Bayesian loop closure detector.
+  _meta:
+    stars: 3609
+    last_commit: '2026-01-31'
+    language: C++
 
 - name: SRBA
   url: http://mrpt.github.io/srba/
   github: MRPT/srba
   description: Solving SLAM/BA in relative coordinates with flexibility for different submapping strategies.
+  _meta:
+    stars: 76
+    last_commit: '2018-09-30'
+    language: C++
 
 - name: Awesome SLAM Datasets
   url: https://github.com/youngguncho/awesome-slam-datasets
   github: youngguncho/awesome-slam-datasets
   description: Curated list of SLAM-related datasets.
   _subsection: SLAM Dataset
+  _meta:
+    stars: 1907
+    last_commit: '2024-12-13'

--- a/data/vision.yaml
+++ b/data/vision.yaml
@@ -1,17 +1,27 @@
-# vision
-# Source of truth — edit this file, then run: pixi run generate
-
 - name: ViSP
   url: http://visp.inria.fr/
   github: lagadic/visp
   description: Visual Servoing Platform.
+  _meta:
+    stars: 849
+    last_commit: '2026-01-31'
+    license: GPL-2.0
+    language: C++
 
 - name: BundleTrack
   url: https://github.com/wenbowen123/BundleTrack
   github: wenbowen123/BundleTrack
   description: 6D Pose Tracking for Novel Objects without 3D Models.
+  _meta:
+    stars: 678
+    last_commit: '2023-10-13'
+    language: C++
 
 - name: se(3)-TrackNet
   url: https://github.com/wenbowen123/iros20-6d-pose-tracking
   github: wenbowen123/iros20-6d-pose-tracking
   description: 6D Pose Tracking for Novel Objects without 3D Models.
+  _meta:
+    stars: 420
+    last_commit: '2023-08-30'
+    language: Python


### PR DESCRIPTION
## Summary

- **Dynamics → bullets**: Convert dynamics-simulation section from the old table format to bullet lists with text star counts (e.g., `⭐ 14.2k`) — matching all other sections
- **Descriptions**: Add one-line descriptions to all 45 dynamics-simulation entries
- **Metadata**: Populate `_meta` fields (stars, last_commit, archived, license, language) for all 191 entries via `fetch_metadata.py`
- **`--sort` flag**: New CLI option for the generator — `--sort {name,stars,last_commit,none}` (default: `name`). Sorts within each subsection while preserving parent→child adjacency
- **Dead code cleanup**: Remove `dynamics_table` and `simple_table` render modes and all associated functions (`_render_dynamics_row`, `_render_simple_table`, `DYNAMICS_HEADER`, `DYNAMICS_LEGEND`)
- **COMPARISONS.md rewrite**: Complete rewrite from the 2016 version (6 libraries, mostly empty) to a modern comparison page with physics engine feature matrix, robotics dynamics library comparison, decision guide, and benchmark resources
- **Cross-link**: Dynamics-simulation section description now links to `COMPARISONS.md`

## Verification

- `pixi run check` passes (validate 216 entries + generate README)
- `--sort stars` and `--sort last_commit` tested manually