### PR TITLE
ci: enable GitHub Pages with Jekyll Cayman theme

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,3 @@
+theme: jekyll-theme-cayman
+title: Awesome Robotics Libraries
+description: A curated list of robotics simulators and libraries.


### PR DESCRIPTION
## Summary

- Add `_config.yml` with Cayman theme to enable GitHub Pages from main branch
- Pages enabled via API (source: main branch, path: /)
- Site will be live at https://jslee02.github.io/awesome-robotics-libraries/ after merge