### PR TITLE
content: add iCub, close Geometric Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ _Libraries and tools for robotic grasping and manipulation._
 _Environments and models for humanoid robot research._
 
 * 🟡 [Humanoid-Gym](https://github.com/roboterax/humanoid-gym) - Reinforcement learning environment for humanoid robot locomotion. [⭐ 1.8k](https://github.com/roboterax/humanoid-gym)
+* 🟢 [iCub](http://www.icub.org/) - Open-source cognitive humanoid robotic platform for embodied cognition research. [⭐ 117](https://github.com/robotology/icub-main)
 * 🟢 [Legged Gym](https://github.com/leggedrobotics/legged_gym) - Isaac Gym environments for legged robot locomotion training. [⭐ 2.7k](https://github.com/leggedrobotics/legged_gym)
 * 🟢 [MuJoCo Menagerie](https://github.com/google-deepmind/mujoco_menagerie) - Collection of well-tuned MuJoCo models for research and development. [⭐ 3k](https://github.com/google-deepmind/mujoco_menagerie)
 

--- a/data/humanoid-robotics.yaml
+++ b/data/humanoid-robotics.yaml
@@ -1,3 +1,12 @@
+- name: iCub
+  url: http://www.icub.org/
+  github: robotology/icub-main
+  description: Open-source cognitive humanoid robotic platform for embodied cognition research.
+  _meta:
+    stars: 117
+    last_commit: '2025-12-11'
+    language: C++
+
 - name: Humanoid-Gym
   url: https://github.com/roboterax/humanoid-gym
   github: roboterax/humanoid-gym


### PR DESCRIPTION
## Summary

Resolves two legacy issues from 2018 (pre-automation):

- **#15 iCub** — Adds [iCub](http://www.icub.org/) (`robotology/icub-main`) to Humanoid Robotics. 117 stars, active (Dec 2025), well-known humanoid platform from IIT. Passes 4/4 auto-checks.
- **#16 Geometric Tools** — Closing as out-of-scope. It's a general math/geometry/graphics library, not robotics-specific. 1.3k stars and active, but doesn't fit the list's focus.

Closes #15