### PR TITLE
Use shared maintenance workflows

### DIFF
--- a/.github/workflows/protect-readme.yml
+++ b/.github/workflows/protect-readme.yml
@@ -7,37 +7,4 @@ on:
 
 jobs:
   check-readme:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Block direct README edits
-        # Skip for bot-authored PRs (auto-fix links, add-accepted-entry, etc.)
-        if: github.event.pull_request.user.type != 'Bot'
-        uses: actions/github-script@v9
-        with:
-          script: |
-            const files = await github.paginate(github.rest.pulls.listFiles, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.payload.pull_request.number,
-              per_page: 100,
-            });
-
-            const hasSourceChanges = files.some(f =>
-              f.filename.startsWith('data/') ||
-              f.filename.startsWith('scripts/') ||
-              f.filename.startsWith('schema/')
-            );
-
-            if (!hasSourceChanges) {
-              core.setFailed(
-                '❌ README.md must not be edited directly.\n\n' +
-                'This repository uses a YAML-first workflow — README.md is auto-generated ' +
-                'from data/*.yaml files.\n\n' +
-                '📋 To suggest adding a resource, please open an issue instead:\n' +
-                `   https://github.com/${context.repo.owner}/${context.repo.repo}/issues/new/choose\n\n` +
-                '🔧 To fix an existing entry, edit the relevant data/*.yaml file.\n\n' +
-                'See CONTRIBUTING.md for details.'
-              );
-            }
-
-            console.log('✅ README.md change accompanied by source file changes — OK');
+    uses: jslee02/awesome-list-infra/.github/workflows/protect-readme.yml@main

--- a/.github/workflows/refresh-metadata.yml
+++ b/.github/workflows/refresh-metadata.yml
@@ -1,0 +1,14 @@
+name: Refresh Metadata
+
+on:
+  schedule:
+    - cron: "0 8 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  refresh:
+    uses: jslee02/awesome-list-infra/.github/workflows/refresh-metadata.yml@main


### PR DESCRIPTION
## Summary
- Replace copied README-protection workflow logic with the shared reusable workflow
- Add scheduled metadata refresh workflow where the repo already has `scripts/fetch_metadata.py`
- Keep metadata refresh jobs staggered across the week to avoid unnecessary API bursts

## Validation
- Parsed all updated workflow YAML with PyYAML
- `git diff --check`
