### PR TITLE
Add CERT-FLOW (certified route planning under drifting costs)

### DIFF
--- a/data/motion-planning.yaml
+++ b/data/motion-planning.yaml
@@ -15,6 +15,9 @@
     last_commit: '2026-06-04'
     license: MIT
     language: Python
+- name: CERT-FLOW
+  github: Archerkattri/CERT-FLOW
+  description: 'Certified route planning under drifting costs: conformal LB <= OPT <= UB certificates on the optimal route, certificate-directed sensing, certified Contraction Hierarchies.'
 - name: Bonxai
   github: facontidavide/Bonxai
   description: Brutally fast, sparse, 3D Voxel Grid (formerly Treexy).


### PR DESCRIPTION
Adds CERT-FLOW to Motion Planning and Control: an MIT-licensed, pip-installable Python library (pip install certflow) for route planning when edge costs drift. Each replanning round emits a high-probability conformal certificate LB <= OPT <= UB on the optimal route cost (non-exchangeable weighted conformal prediction plus ACI), directs paid sensing at the edges that shrink the certified gap fastest, and proof-gates preprocessing (certified Contraction Hierarchies). Actively maintained, released this week: 223 tests, 16 reproduction pipelines, validated on replayed METR-LA and PEMS-BAY traffic. Zenodo DOI: 10.5281/zenodo.20631475. Disclosure: I am the author.