### PR TITLE
Limit refresh metadata secret forwarding

### DIFF
--- a/.github/workflows/refresh-metadata.yml
+++ b/.github/workflows/refresh-metadata.yml
@@ -12,4 +12,5 @@ permissions:
 jobs:
   refresh:
     uses: jslee02/awesome-list-infra/.github/workflows/refresh-metadata.yml@main
-    secrets: inherit
+    secrets:
+      CREATE_PR_TOKEN: ${{ secrets.CREATE_PR_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -217,4 +217,5 @@ git push
 For metadata PRs to trigger normal pull-request CI without manual approval,
 configure a repository secret named `CREATE_PR_TOKEN` with a fine-grained bot
 token or GitHub App token that has `contents: write` and `pull-requests: write`.
-The workflow falls back to `GITHUB_TOKEN` when that secret is not present.
+The workflow falls back to `GITHUB_TOKEN` when that secret is not present. The
+caller forwards only `CREATE_PR_TOKEN` to the reusable workflow.


### PR DESCRIPTION
## Summary

Addresses follow-up review feedback from #119.

- Replaces `secrets: inherit` with an explicit `CREATE_PR_TOKEN` mapping for the refresh metadata reusable workflow.
- Updates maintainer docs to note that only `CREATE_PR_TOKEN` is forwarded.

## Validation

- Workflow YAML parse for `.github/workflows/refresh-metadata.yml`
- `python3 scripts/validate_entries.py`
- `git diff --check`

Addresses https://github.com/jslee02/awesome-robotics-libraries/pull/119#pullrequestreview-4632336425
