### PR TITLE
Use shared stale author-action issue workflow

### DIFF
--- a/.github/workflows/evaluate-submission.yml
+++ b/.github/workflows/evaluate-submission.yml
@@ -2,11 +2,13 @@ name: Evaluate Submission
 
 on:
   issues:
-    types: [labeled]
+    types: [edited, labeled]
+  issue_comment:
+    types: [created]
 
 jobs:
   evaluate:
-    if: github.event.label.name == 'suggestion'
+    if: github.event_name == 'issues' && github.event.action == 'labeled' && github.event.label.name == 'suggestion'
     runs-on: ubuntu-latest
     permissions:
       actions: write
@@ -156,3 +158,44 @@ jobs:
               issue_number: context.issue.number,
               labels: ['needs-review', 'question']
             });
+
+  clear-author-question:
+    if: |
+      (github.event_name == 'issues' && github.event.action == 'edited') ||
+      (github.event_name == 'issue_comment' && !github.event.issue.pull_request)
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Clear author-action labels after author update
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const labels = (issue.labels || []).map(label => typeof label === 'string' ? label : label.name);
+            if (!labels.includes('suggestion') || !labels.includes('question')) {
+              return;
+            }
+
+            const author = issue.user.login;
+            const sender = context.payload.sender.login;
+            if (sender !== author) {
+              return;
+            }
+
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issue_number = issue.number;
+
+            async function removeLabel(label) {
+              try {
+                await github.rest.issues.removeLabel({ owner, repo, issue_number, name: label });
+              } catch (error) {
+                if (error.status !== 404) {
+                  throw error;
+                }
+              }
+            }
+
+            await removeLabel('question');
+            await removeLabel('stale');

--- a/.github/workflows/evaluate-submission.yml
+++ b/.github/workflows/evaluate-submission.yml
@@ -145,12 +145,14 @@ jobs:
                 'I couldn\'t find a GitHub repository in this issue. Could you add the **GitHub Repository** field ',
                 '(e.g., `owner/repo`) so I can run an automated evaluation?',
                 '',
-                'If the project isn\'t on GitHub, no worries — a maintainer will review it manually.',
+                'If the project isn\'t on GitHub, please reply confirming that this should be reviewed as a non-GitHub resource and include any public repository or documentation link maintainers should use.',
+                '',
+                'This issue is labeled `question` while waiting for author input. If there is no update for about two weeks, automation will mark it stale; after another two weeks without activity, it may close automatically.',
               ].join('\n')
             });
             await github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              labels: ['needs-review']
+              labels: ['needs-review', 'question']
             });

--- a/.github/workflows/stale-author-action-issues.yml
+++ b/.github/workflows/stale-author-action-issues.yml
@@ -1,0 +1,15 @@
+name: Stale Author-Action Issues
+
+on:
+  schedule:
+    - cron: "0 10 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  stale:
+    uses: jslee02/awesome-list-infra/.github/workflows/stale-author-action-issues.yml@main

--- a/.github/workflows/stale-author-action-issues.yml
+++ b/.github/workflows/stale-author-action-issues.yml
@@ -6,6 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: write
   contents: read
   issues: write
   pull-requests: read

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -210,6 +210,7 @@ git push
 |----------|----------|-------------|
 | Check Links | Weekly (Mon 8am UTC) | Checks for broken links; auto-creates fix PRs |
 | Refresh Metadata | Weekly (Mon 8am UTC) | Updates GitHub metadata, regenerates README, validates, and creates a maintenance PR |
+| Stale Author-Action Issues | Daily | Marks suggestion issues stale after 14 days waiting for author input, then closes after another 14 days |
 | Validate Data | On PR | Validates YAML schema and README freshness |
 | Audit Direct Resource PRs | On PR | Closes direct human PRs that add new resources and redirects them to the suggestion issue form |
 | Protect README | On PR | Blocks direct README.md edits without data changes |


### PR DESCRIPTION
## Summary

Wires this repository into the shared stale author-action issue workflow.

- Adds a daily `Stale Author-Action Issues` workflow that calls `awesome-list-infra`.
- Updates the missing-GitHub-repo fallback comment to ask the author to either provide a GitHub repo or confirm non-GitHub review.
- Labels those waiting suggestions with `question`, so only `suggestion` + `question` issues enter the stale queue.
- Documents the 14-day stale / 14-day close behavior in `CONTRIBUTING.md`.

## Dependency

Merge after the reusable workflow is available from `jslee02/awesome-list-infra@main`:
https://github.com/jslee02/awesome-list-infra/pull/8

## Validation

- Parsed `.github/workflows/stale-author-action-issues.yml` and `.github/workflows/evaluate-submission.yml` with PyYAML.
- `python3 scripts/validate_entries.py`
- `git diff --check`

## Notes

Issue #105 is the motivating example: it has `suggestion`/`needs-review` and a bot request for missing GitHub repo details, but no author follow-up. This change makes future cases like that enter the `question`-based stale path instead of staling every `needs-review` suggestion.
