### PR TITLE
[codex] Improve author-action issue labeling

### DIFF
--- a/.github/workflows/add-accepted-entry.yml
+++ b/.github/workflows/add-accepted-entry.yml
@@ -9,6 +9,10 @@ on:
         description: Issue number to process
         required: true
         type: number
+      github_repo:
+        description: GitHub repository evaluated by the submission workflow
+        required: false
+        type: string
 
 jobs:
   add-entry:
@@ -76,8 +80,13 @@ jobs:
             const category = extractField(body, 'Category');
             const description = extractField(body, 'Description');
 
-            // GitHub repo: from structured field or from URL
-            let ghRepo = normalizeGitHubRepo(extractField(body, 'GitHub Repository'));
+            // GitHub repo: from dispatch input, structured field, or URL
+            let ghRepo = context.eventName === 'workflow_dispatch'
+              ? normalizeGitHubRepo('${{ inputs.github_repo }}')
+              : '';
+            if (!ghRepo) {
+              ghRepo = normalizeGitHubRepo(extractField(body, 'GitHub Repository'));
+            }
             if (!ghRepo) {
               const urlMatch = body.match(/github\.com\/([a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+)/);
               if (urlMatch) ghRepo = urlMatch[1];

--- a/.github/workflows/evaluate-submission.yml
+++ b/.github/workflows/evaluate-submission.yml
@@ -8,7 +8,10 @@ on:
 
 jobs:
   evaluate:
-    if: github.event_name == 'issues' && github.event.action == 'labeled' && github.event.label.name == 'suggestion'
+    if: |
+      (github.event_name == 'issues' && github.event.action == 'labeled' && github.event.label.name == 'suggestion') ||
+      (github.event_name == 'issues' && github.event.action == 'edited' && contains(github.event.issue.labels.*.name, 'suggestion') && contains(github.event.issue.labels.*.name, 'question') && github.event.sender.login == github.event.issue.user.login) ||
+      (github.event_name == 'issue_comment' && !github.event.issue.pull_request && contains(github.event.issue.labels.*.name, 'suggestion') && contains(github.event.issue.labels.*.name, 'question') && github.event.sender.login == github.event.issue.user.login)
     runs-on: ubuntu-latest
     permissions:
       actions: write
@@ -29,6 +32,11 @@ jobs:
         with:
           script: |
             const body = context.payload.issue.body || '';
+            const commentBody = context.payload.comment ? context.payload.comment.body || '' : '';
+            const authorUpdate =
+              context.eventName === 'issue_comment' ||
+              (context.eventName === 'issues' && context.payload.action === 'edited');
+            core.setOutput('author_update', authorUpdate ? 'true' : 'false');
 
             function normalizeGitHubRepo(value) {
               if (!value) return '';
@@ -37,7 +45,20 @@ jobs:
               return slugMatch ? slugMatch[1] : '';
             }
 
-            // Try the structured "github" field first (from issue template)
+            function extractGitHubRepo(text, { allowBareSlug = false } = {}) {
+              const urlMatch = text.match(/github\.com\/([a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+)/);
+              if (urlMatch) {
+                return normalizeGitHubRepo(urlMatch[1]);
+              }
+
+              if (!allowBareSlug) {
+                return '';
+              }
+              const slugMatch = text.match(/(?:^|[\s`])([a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+)(?:[\s`.,;:]|$)/);
+              return slugMatch ? normalizeGitHubRepo(slugMatch[1]) : '';
+            }
+
+            // Try the structured "github" field first (from issue template).
             const ghFieldMatch = body.match(/### GitHub Repository\s*\n\s*\n?\s*([\s\S]*?)(?=\n###|$)/);
             const ghRepo = normalizeGitHubRepo(ghFieldMatch ? ghFieldMatch[1] : '');
             if (ghRepo) {
@@ -45,14 +66,66 @@ jobs:
               return;
             }
 
-            // Fallback: extract from any GitHub URL in the body
-            const urlMatch = body.match(/github\.com\/([a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+)/);
-            if (urlMatch) {
-              core.setOutput('repo', urlMatch[1]);
+            const commentRepo = authorUpdate
+              ? extractGitHubRepo(commentBody, { allowBareSlug: true })
+              : '';
+            if (commentRepo) {
+              core.setOutput('repo', commentRepo);
+              return;
+            }
+
+            const fallbackRepo = extractGitHubRepo(body);
+            if (fallbackRepo) {
+              core.setOutput('repo', fallbackRepo);
               return;
             }
 
             core.setOutput('repo', '');
+
+      - name: Persist resolved GitHub repo in issue body
+        if: steps.extract.outputs.repo != ''
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issue_number = context.issue.number;
+            const resolvedRepo = '${{ steps.extract.outputs.repo }}';
+            const body = context.payload.issue.body || '';
+
+            function normalizeGitHubRepo(value) {
+              if (!value) return '';
+              const trimmed = value.trim();
+              const slugMatch = trimmed.match(/^(?:https?:\/\/github\.com\/)?([a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+?)(?:\.git|\/)?$/);
+              return slugMatch ? slugMatch[1] : '';
+            }
+
+            function bodyGitHubRepo(text) {
+              const fieldMatch = text.match(/### GitHub Repository\s*\n\s*\n?\s*([\s\S]*?)(?=\n###|$)/);
+              const fieldRepo = normalizeGitHubRepo(fieldMatch ? fieldMatch[1] : '');
+              if (fieldRepo) {
+                return fieldRepo;
+              }
+
+              const urlMatch = text.match(/github\.com\/([a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+)/);
+              return urlMatch ? normalizeGitHubRepo(urlMatch[1]) : '';
+            }
+
+            if (bodyGitHubRepo(body)) {
+              return;
+            }
+
+            const fieldRe = /(### GitHub Repository\s*\n\s*\n?)([\s\S]*?)(?=\n###|$)/;
+            const newBody = fieldRe.test(body)
+              ? body.replace(fieldRe, `$1${resolvedRepo}\n\n`)
+              : `${body.trimEnd()}\n\n### GitHub Repository\n\n${resolvedRepo}\n`;
+
+            await github.rest.issues.update({
+              owner,
+              repo,
+              issue_number,
+              body: newBody,
+            });
 
       - name: Run evaluation
         if: steps.extract.outputs.repo != ''
@@ -94,6 +167,16 @@ jobs:
             const owner = context.repo.owner;
             const repo = context.repo.repo;
 
+            async function removeLabel(name) {
+              try {
+                await github.rest.issues.removeLabel({ owner, repo, issue_number: issue, name });
+              } catch (error) {
+                if (error.status !== 404) {
+                  throw error;
+                }
+              }
+            }
+
             // Archived rejects close immediately; 0-score rejects stay in incubator queue
             let label;
             if (rec === 'reject' && archived) {
@@ -109,6 +192,10 @@ jobs:
               };
               label = labelMap[rec] || 'needs-review';
             }
+
+            for (const name of ['question', 'stale', 'needs-review', 'accepted', 'incubator', 'rejected', 'duplicate']) {
+              await removeLabel(name);
+            }
             await github.rest.issues.addLabels({ owner, repo, issue_number: issue, labels: [label] });
 
             if (label === 'accepted') {
@@ -119,6 +206,7 @@ jobs:
                 ref: context.payload.repository.default_branch,
                 inputs: {
                   issue_number: String(issue),
+                  github_repo: '${{ steps.extract.outputs.repo }}',
                 },
               });
             }
@@ -133,14 +221,28 @@ jobs:
             }
 
       - name: Post fallback comment (no repo found)
-        if: steps.extract.outputs.repo == ''
+        if: steps.extract.outputs.repo == '' && steps.extract.outputs.author_update != 'true'
         uses: actions/github-script@v9
         with:
           script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issue_number = context.issue.number;
+
+            async function removeLabel(name) {
+              try {
+                await github.rest.issues.removeLabel({ owner, repo, issue_number, name });
+              } catch (error) {
+                if (error.status !== 404) {
+                  throw error;
+                }
+              }
+            }
+
             await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
+              owner,
+              repo,
+              issue_number,
               body: [
                 '👋 Thanks for the suggestion!',
                 '',
@@ -152,40 +254,23 @@ jobs:
                 'This issue is labeled `question` while waiting for author input. If there is no update for about two weeks, automation will mark it stale; after another two weeks without activity, it may close automatically.',
               ].join('\n')
             });
+            await removeLabel('needs-review');
+            await removeLabel('stale');
             await github.rest.issues.addLabels({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              labels: ['needs-review', 'question']
+              owner,
+              repo,
+              issue_number,
+              labels: ['question']
             });
 
-  clear-author-question:
-    if: |
-      (github.event_name == 'issues' && github.event.action == 'edited') ||
-      (github.event_name == 'issue_comment' && !github.event.issue.pull_request)
-    runs-on: ubuntu-latest
-    permissions:
-      issues: write
-    steps:
-      - name: Clear author-action labels after author update
+      - name: Queue manual review after author update without repo
+        if: steps.extract.outputs.repo == '' && steps.extract.outputs.author_update == 'true'
         uses: actions/github-script@v9
         with:
           script: |
-            const issue = context.payload.issue;
-            const labels = (issue.labels || []).map(label => typeof label === 'string' ? label : label.name);
-            if (!labels.includes('suggestion') || !labels.includes('question')) {
-              return;
-            }
-
-            const author = issue.user.login;
-            const sender = context.payload.sender.login;
-            if (sender !== author) {
-              return;
-            }
-
             const owner = context.repo.owner;
             const repo = context.repo.repo;
-            const issue_number = issue.number;
+            const issue_number = context.issue.number;
 
             async function removeLabel(label) {
               try {
@@ -199,3 +284,19 @@ jobs:
 
             await removeLabel('question');
             await removeLabel('stale');
+            await github.rest.issues.addLabels({
+              owner,
+              repo,
+              issue_number,
+              labels: ['needs-review'],
+            });
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number,
+              body: [
+                'Thanks for the update.',
+                '',
+                'I still could not find a GitHub repository to evaluate automatically, so I moved this suggestion to manual maintainer review.',
+              ].join('\n'),
+            });

--- a/.github/workflows/stale-author-action-issues.yml
+++ b/.github/workflows/stale-author-action-issues.yml
@@ -12,5 +12,178 @@ permissions:
   pull-requests: read
 
 jobs:
+  prepare-author-action-labels:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Backfill legacy author-action labels
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const questionLabel = 'question';
+            const reviewLabel = 'needs-review';
+            const staleLabel = 'stale';
+            const outcomeLabels = new Set(['accepted', 'incubator', 'rejected', 'duplicate']);
+            const staleAfterDays = 14;
+            const maxOperations = 30;
+            const staleMarker = '<!-- author-action-stale -->';
+            const staleMessage = [
+              staleMarker,
+              'This suggestion has been marked stale because we asked for more information and have not seen an author update for about two weeks.',
+              '',
+              'Please update the issue with the requested details, or reply confirming that it should be reviewed as a non-GitHub resource. The stale label will be removed automatically after new activity. If there is no update in another two weeks, this issue will be closed.',
+            ].join('\n');
+
+            async function removeLabel(issue_number, name) {
+              try {
+                await github.rest.issues.removeLabel({ owner, repo, issue_number, name });
+              } catch (error) {
+                if (error.status !== 404) {
+                  throw error;
+                }
+              }
+            }
+
+            async function ensureStaleLabel() {
+              try {
+                await github.rest.issues.getLabel({ owner, repo, name: staleLabel });
+              } catch (error) {
+                if (error.status !== 404) {
+                  throw error;
+                }
+                await github.rest.issues.createLabel({
+                  owner,
+                  repo,
+                  name: staleLabel,
+                  color: 'ededed',
+                  description: 'No author response after requested updates',
+                });
+              }
+            }
+
+            function normalizeGitHubRepo(value) {
+              if (!value) return '';
+              const trimmed = value.trim();
+              const slugMatch = trimmed.match(/^(?:https?:\/\/github\.com\/)?([a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+?)(?:\.git|\/)?$/);
+              return slugMatch ? slugMatch[1] : '';
+            }
+
+            function extractGitHubRepo(text) {
+              const fieldMatch = text.match(/### GitHub Repository\s*\n\s*\n?\s*([\s\S]*?)(?=\n###|$)/);
+              const fieldRepo = normalizeGitHubRepo(fieldMatch ? fieldMatch[1] : '');
+              if (fieldRepo) {
+                return fieldRepo;
+              }
+
+              const urlMatch = text.match(/github\.com\/([a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+)/);
+              return urlMatch ? normalizeGitHubRepo(urlMatch[1]) : '';
+            }
+
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
+              owner,
+              repo,
+              state: 'open',
+              labels: `suggestion,${reviewLabel}`,
+              per_page: 100,
+            });
+            const cutoff = new Date(Date.now() - staleAfterDays * 24 * 60 * 60 * 1000);
+            let operations = 0;
+
+            for (const issue of issues) {
+              if (operations >= maxOperations) {
+                break;
+              }
+
+              const labels = new Set(issue.labels.map(label => typeof label === 'string' ? label : label.name));
+              if ([...outcomeLabels].some(label => labels.has(label))) {
+                continue;
+              }
+
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner,
+                repo,
+                issue_number: issue.number,
+                per_page: 100,
+              });
+              const requestComment = [...comments].reverse().find(comment =>
+                comment.user.login === 'github-actions[bot]' &&
+                comment.body.includes("couldn't find a GitHub repository") &&
+                comment.body.includes('GitHub Repository')
+              );
+              if (!requestComment) {
+                continue;
+              }
+
+              const timeline = await github.paginate(github.rest.issues.listEventsForTimeline, {
+                owner,
+                repo,
+                issue_number: issue.number,
+                per_page: 100,
+              });
+              const requestDate = new Date(requestComment.created_at);
+              const authorUpdatedAfterRequest = timeline.some(event =>
+                ['commented', 'edited'].includes(event.event) &&
+                (event.actor?.login || event.user?.login) === issue.user.login &&
+                new Date(event.created_at) > requestDate
+              );
+              const editResponse = await github.graphql(`
+                query($owner: String!, $repo: String!, $number: Int!) {
+                  repository(owner: $owner, name: $repo) {
+                    issue(number: $number) {
+                      lastEditedAt
+                    }
+                  }
+                }
+              `, {
+                owner,
+                repo,
+                number: issue.number,
+              });
+              const lastEditedAt = editResponse.repository.issue.lastEditedAt;
+              const bodyEditedAfterRequest =
+                lastEditedAt && new Date(lastEditedAt) > requestDate;
+
+              if (authorUpdatedAfterRequest || bodyEditedAfterRequest || extractGitHubRepo(issue.body || '')) {
+                continue;
+              }
+
+              await removeLabel(issue.number, reviewLabel);
+              if (!labels.has(questionLabel)) {
+                await github.rest.issues.addLabels({
+                  owner,
+                  repo,
+                  issue_number: issue.number,
+                  labels: [questionLabel],
+                });
+              }
+              operations += 1;
+
+              const requestAgeExceeded = new Date(requestComment.created_at) <= cutoff;
+              if (requestAgeExceeded && !labels.has(staleLabel)) {
+                await ensureStaleLabel();
+                await github.rest.issues.addLabels({
+                  owner,
+                  repo,
+                  issue_number: issue.number,
+                  labels: [staleLabel],
+                });
+
+                const alreadyCommented = comments.some(comment => comment.body.includes(staleMarker));
+                if (!alreadyCommented) {
+                  await github.rest.issues.createComment({
+                    owner,
+                    repo,
+                    issue_number: issue.number,
+                    body: staleMessage,
+                  });
+                }
+                operations += 1;
+              }
+            }
+
   stale:
+    needs: prepare-author-action-labels
     uses: jslee02/awesome-list-infra/.github/workflows/stale-author-action-issues.yml@main


### PR DESCRIPTION
## Summary
- make `question` the author-action label and `needs-review` the maintainer-action label in the submission evaluator
- rerun evaluation when the issue author edits/comments with a GitHub repo while an issue is waiting on `question`
- move author updates without a GitHub repo into manual review instead of leaving them stale-eligible
- backfill legacy `suggestion` + `needs-review` issues that already received the missing-GitHub-repo bot request, marking overdue ones stale immediately

## Expected behavior
- new missing-repo suggestions get `question`, not `needs-review`
- after an author update, `question`/`stale` are removed
- #105 matches the legacy backfill criteria and should be moved to `question` + `stale` on the next stale workflow run

## Validation
- `python3 scripts/validate_entries.py data`
- workflow YAML parse for `evaluate-submission.yml` and `stale-author-action-issues.yml`
- embedded `actions/github-script` JavaScript checked with `node --check`
- `git diff --check`
