### PR TITLE
Add FusionCore (ROS 2 UKF sensor fusion)

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,7 @@ _Other robotics-related tools and utilities._
 
 * [Foxglove Studio](https://foxglove.dev) - A fully integrated visualization and debugging desktop app for your robotics data.
 * 🟢 fuse - General architecture for performing sensor fusion live on a robot. [⭐ 868](https://github.com/locusrobotics/fuse)
+* 🟢 FusionCore - ROS 2 UKF fusing GPS, IMU, and wheel odometry with adaptive noise and GPS outlier rejection for robust outdoor localization. [⭐ 272](https://github.com/manankharwar/fusioncore)
 
 ## [Simulators](#contents)
 


### PR DESCRIPTION
FusionCore is a ROS 2 UKF fusing GPS, IMU, and wheel odometry with adaptive noise estimation and chi-squared GPS outlier rejection for robust outdoor localization. It is maintained, documented, released, and benchmarked against robot_localization on the NCLT dataset (paper: https://arxiv.org/abs/2605.25239).

Placed in the ETC section next to `fuse` as the closest sensor-fusion analog.